### PR TITLE
Persist the centreline, pin the unit convention and keep thin vessels connected

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,38 @@ obey Murray's law and bifurcation angles follow Zamir's minimum-volume rule.
 3. **Interpolation** (`utils.py`): each stem is smoothed with a cubic B-spline.
 4. **Voxelisation** (`computeVoxel.py`): the network is mapped into the volume
    with a single isotropic scale factor and every segment is drawn as a tapered
-   capsule, so calibre and bifurcation angles survive into the image.
+   capsule, so calibre and bifurcation angles survive into the image, plus a
+   connected digital line, so a vessel thinner than a voxel stays unbroken.
+
+Steps 1–3 produce the **centreline**, which is saved alongside the volume. The
+centreline is the source of truth for the geometry and the TIFF is one
+rasterisation of it, so step 4 can be repeated at any resolution without
+regenerating the network.
+
+---
+
+## Units
+
+One grammar unit is **one micrometre**. Nothing in the code enforces this — the
+generator is scale free — but every output declares it, so that a dataset cannot
+be silently mis-scaled:
+
+- `--d0` and `--d-min` are vessel diameters in micrometres;
+- `--voxel-size` is *grammar units per voxel*, and therefore a modality's
+  physical voxel size in micrometres per voxel;
+- `epsilon` (the length-to-diameter ratio) is dimensionless, so segment lengths
+  follow the diameters;
+- every JSON sidecar records `"units": "um"`.
+
+A vessel of diameter `d` rendered with `--fit voxel_size --voxel-size v` is
+`d / v` voxels across, so calibre in voxels scales as `1 / v` and the same
+centreline rendered at two voxel sizes gives two correctly scaled datasets.
+Rasterising once and resampling the binary volume afterwards does **not**: it
+destroys vessels a voxel wide. Render each modality from the centreline instead.
+
+To work in another unit, keep the convention self-consistent — interpret `--d0`
+and `--voxel-size` in the same unit — and declare it with `--units mm`. The flag
+labels the data; it rescales nothing.
 
 ---
 
@@ -49,10 +80,19 @@ Generate five networks into `./output`, reproducibly:
 python main.py --count 5 --out ./output --seed 1
 ```
 
-Each network is written as `Lnet_i<generations>_s<seed>.tiff`, a uint8 TIFF of
-0 and 255 whose pages are z, rows y and columns x, next to a JSON sidecar with the
-seed and every parameter used. Network *i* of a run uses `seed + i`, and the same
-seed and parameters reproduce the same file.
+Each network is written as three files sharing the stem
+`Lnet_i<generations>_s<seed>`:
+
+| File | Contents |
+| --- | --- |
+| `.tiff` | a uint8 volume of 0 and 255 whose pages are z, rows y and columns x |
+| `.npz` | the centreline: `nodes`, the (4, N) array of x, y, z and diameter in grammar units with NaN column separators; `program`, the grammar string; and `metadata`, the sidecar record |
+| `.json` | the seed, the unit convention and every parameter used |
+
+Network *i* of a run uses `seed + i`, and the same seed and parameters reproduce
+the same volume. The centreline archive is a few hundred kilobytes against
+hundreds of megabytes for a volume, and its arrays are exact; being a zip, its
+entries carry a modification time, so compare the arrays rather than the bytes.
 
 Useful options (`python main.py --help` lists them all):
 
@@ -61,6 +101,7 @@ Useful options (`python main.py --help` lists them all):
 | `--volume NX NY NZ` | `512 512 140` | volume shape in voxels |
 | `--iterations MIN MAX` | `4 12` | drawn generations, drawn uniformly |
 | `--d0 MEAN STD` | `20 5` | root diameter, grammar units, truncated at `--d0-min` |
+| `--d-min` | none | smallest drawn vessel diameter; a branch stops bifurcating below it |
 | `--epsilon MIN MAX` | `4 10` | length-to-diameter ratio of a segment |
 | `--randmarg MIN MAX` | `0.1 0.3` | relative half-width of the segment-length distribution |
 | `--sigma` | `5` | d_opt / sigma is the spread of the first daughter diameter |
@@ -68,20 +109,88 @@ Useful options (`python main.py --help` lists them all):
 | `--stem-angle` | `25` | turn between the five sub-segments of a stem, degrees |
 | `--aneurysm-prob`, `--stenosis-prob` | `0.02` | per sub-segment probability of a local ×1.5 dilation or ×0.5 constriction |
 | `--fit` | `isotropic` | `isotropic`, `voxel_size` (fixed `--voxel-size`) or `stretch` (legacy per-axis fill) |
+| `--voxel-size` | none | grammar units per voxel for `--fit voxel_size`: the modality's voxel size |
 | `--clip-axes` | `z` | axes left out of the isotropic fit and clipped, as an imaging slab would |
+| `--no-connect` | off | rasterise bare capsules, leaving sub-voxel vessels dotted |
+| `--units` | `um` | the unit one grammar unit stands for, recorded in the sidecar |
+
+`--d-min` and `--iterations` are both stopping criteria and whichever comes first
+wins. `--d-min` is the one a modality states directly, as its smallest resolvable
+calibre; diameters fall by `2^(-1/k)` a generation, so it is reached after about
+`log(d0 / d_min) / log(2^(1/k))` generations — raise `--iterations` above that to
+let `--d-min` decide. It bounds the diameter a branch is *drawn* at, not the
+diameter after a local anomaly: a stenosis still narrows a drawn sub-segment by
+`--stenosis-prob`'s factor of 0.5, so set `--stenosis-prob 0` for a hard floor.
+
+### Connectivity
+
+A capsule sets only the voxels whose centres it contains. A vessel thinner than
+a voxel contains no centre along much of its length, so on its own it rasterises
+as a dotted line and a connected tree falls apart into fragments — with the
+default parameters, more than a third of the centreline is that thin and a
+single tree renders as dozens of pieces. Every segment is therefore also drawn
+as a 26-connected digital line, which renders a sub-voxel vessel one voxel wide
+instead of dotted. It is not a dilation: every voxel the line sets lies within
+`sqrt(3)/2` of the centreline, so for a radius of 0.866 voxels or more it is
+already inside the capsule and calibre is untouched. `--no-connect` restores the
+bare capsule rasterisation.
+
+Two things still legitimately split a rendered network into pieces, and neither
+is a defect:
+
+- **Clipping.** A branch that leaves a slab and re-enters it is two vessels in
+  the image, exactly as it would be in a real acquisition. `--clip-axes` and the
+  volume shape control this; with `--clip-axes none` a fitted network renders as
+  a single connected component.
+- **Resolution.** A vessel the modality cannot resolve is still drawn, one voxel
+  wide. To stop generating them instead, set `--d-min` to the smallest
+  resolvable calibre.
+
+`--clip-axes` is read by the isotropic fit only; `voxel_size` and `stretch`
+ignore it. The command line clips z by default because the default volume is an
+imaging slab, whereas the library functions `computeVoxel.process_network` and
+`fit_to_volume` default to clipping nothing, so that a direct call fits the whole
+network unless told otherwise. Axes may be named or indexed in either place, and
+an axis that is neither raises.
 
 From Python:
 
 ```python
-from main import generate_network
+from main import generate_network, save_network
 
 volume, program, nodes = generate_network(
     niter=8, d0=20.0, properties={"epsilon": 7.0, "randmarg": 0.2}, tVol=(512, 512, 140))
+save_network("Lnet.npz", nodes, program=program)
 ```
 
 `volume` is a uint8 array of 0 and 1 indexed (x, y, z); `program` is the grammar
 string; `nodes` is the (4, N) centreline of x, y, z and diameter with NaN columns
-separating branches.
+separating branches. `nodes` is in grammar units and independent of `tVol`, `fit`
+and `voxel_size`, so it is the artefact worth keeping.
+
+### Rendering one network for several modalities
+
+Because the mapping from grammar units to voxels happens at rasterisation time, a
+saved centreline can be rendered at each modality's own voxel size. The vessel
+calibre distribution of the result — which is exactly what an unpaired
+image-to-image model learns as its output prior — then matches that modality:
+
+```python
+from computeVoxel import process_network
+from main import load_network
+
+network = load_network("output/Lnet_i8_s1.npz")
+
+for modality, voxel_size, shape in [("light-sheet", 2.0, (512, 512, 140)),
+                                    ("mesoscopic-PAI", 20.0, (512, 512, 140))]:
+    volume = process_network(network["nodes"], shape,
+                             fit="voxel_size", voxel_size=voxel_size)
+```
+
+A 20 µm vessel is 10 voxels across at 2 µm and 1 voxel across at 20 µm. Choose
+`--d0`, `--epsilon` and `--iterations` (or `--d-min`) so that the network spans
+the field of view `shape * voxel_size`: under `voxel_size` the network is centred
+and clipped rather than scaled to fit.
 
 ---
 
@@ -126,7 +235,13 @@ python -m unittest discover -s tests -t .
 
 The suite covers the turtle semantics, grammar balance, the bifurcation law,
 the capsule volume at three orientations, angle preservation under the
-isotropic fit, seed determinism and the command-line entry point.
+isotropic fit, the `d_min` stopping criterion, seed determinism and the
+command-line entry point. It also pins the centreline contract: a saved
+centreline re-renders the volume it was generated with, calibre in voxels
+scales as `1 / voxel_size`, and a sidecar plus its `.npz` reproduce the written
+TIFF exactly. Connectivity is covered too: an unclipped network renders as one
+26-connected component, bare capsules do not, and connecting changes nothing
+once a vessel fills a voxel.
 
 ---
 
@@ -153,6 +268,10 @@ Please cite the following if you use V-System in your research:
 
 Version 3.0 changes the interpreter, the grammars and the voxeliser as described
 above; volumes generated with it are not identical to those of earlier versions.
+Version 3.1 adds the centreline archive, the declared unit convention and the
+`d_min` stopping criterion. It also renders sub-voxel vessels as connected
+one-voxel paths rather than dotted lines, so its volumes contain vessels that
+3.0 dropped; `--no-connect` reproduces the 3.0 rasterisation.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ centreline rendered at two voxel sizes gives two correctly scaled datasets.
 Rasterising once and resampling the binary volume afterwards does **not**: it
 destroys vessels a voxel wide. Render each modality from the centreline instead.
 
+The `1 / v` law holds down to the grid: a vessel below one voxel across is drawn
+at the one-voxel connectivity floor rather than scaled, so its rendered calibre
+is overstated. That is the honest rendering of an unresolvable vessel, but it
+means a network must be chosen against the voxel size it will be rendered at —
+see *Rendering one network for several modalities* below.
+
 To work in another unit, keep the convention self-consistent — interpret `--d0`
 and `--voxel-size` in the same unit — and declare it with `--units mm`. The flag
 labels the data; it rescales nothing.
@@ -90,8 +96,10 @@ Each network is written as three files sharing the stem
 | `.json` | the seed, the unit convention and every parameter used |
 
 Network *i* of a run uses `seed + i`, and the same seed and parameters reproduce
-the same volume. The centreline archive is a few hundred kilobytes against
-hundreds of megabytes for a volume, and its arrays are exact; being a zip, its
+the same volume. The centreline archive grows with the number of drawn
+generations rather than with the volume — tens of kilobytes at four generations
+and about seven megabytes at twelve, against 37 MB for a `512 × 512 × 140`
+volume whatever the network inside it. Its arrays are exact; being a zip, its
 entries carry a modification time, so compare the arrays rather than the bytes.
 
 Useful options (`python main.py --help` lists them all):
@@ -116,9 +124,12 @@ Useful options (`python main.py --help` lists them all):
 
 `--d-min` and `--iterations` are both stopping criteria and whichever comes first
 wins. `--d-min` is the one a modality states directly, as its smallest resolvable
-calibre; diameters fall by `2^(-1/k)` a generation, so it is reached after about
-`log(d0 / d_min) / log(2^(1/k))` generations — raise `--iterations` above that to
-let `--d-min` decide. It bounds the diameter a branch is *drawn* at, not the
+calibre; with `--deterministic` daughters, diameters fall by exactly `2^(-1/k)` a
+generation and it is reached after `log(d0 / d_min) / log(2^(1/k))` of them.
+Under the default stochastic daughter diameters that is only an estimate, and
+the two daughters of a bifurcation reach it at different depths, so the tree
+terminates unevenly. Either way, raise `--iterations` above the estimate to let
+`--d-min` decide. It bounds the diameter a branch is *drawn* at, not the
 diameter after a local anomaly: a stenosis still narrows a drawn sub-segment by
 `--stenosis-prob`'s factor of 0.5, so set `--stenosis-prob 0` for a hard floor.
 

--- a/README.md
+++ b/README.md
@@ -171,26 +171,53 @@ and `voxel_size`, so it is the artefact worth keeping.
 ### Rendering one network for several modalities
 
 Because the mapping from grammar units to voxels happens at rasterisation time, a
-saved centreline can be rendered at each modality's own voxel size. The vessel
-calibre distribution of the result — which is exactly what an unpaired
-image-to-image model learns as its output prior — then matches that modality:
+saved centreline can be rendered at each modality's own voxel size. The field of
+view is `shape * voxel_size`, so `shape` has to follow the voxel size to keep it
+fixed; deriving it from the network's own extent does that:
 
 ```python
+import numpy as np
 from computeVoxel import process_network
 from main import load_network
 
+# written by: python main.py --count 1 --seed 1 --iterations 8 8 --out output
 network = load_network("output/Lnet_i8_s1.npz")
+nodes = network["nodes"]
+extent = np.nanmax(nodes[:3], axis=1) - np.nanmin(nodes[:3], axis=1)  # micrometres
 
-for modality, voxel_size, shape in [("light-sheet", 2.0, (512, 512, 140)),
-                                    ("mesoscopic-PAI", 20.0, (512, 512, 140))]:
-    volume = process_network(network["nodes"], shape,
-                             fit="voxel_size", voxel_size=voxel_size)
+for modality, voxel_size in [("two-photon", 1.0), ("light-sheet", 2.0)]:
+    shape = np.ceil(extent / voxel_size).astype(int) + 8   # same field of view, finer grid
+    volume = process_network(nodes, shape, fit="voxel_size", voxel_size=voxel_size)
 ```
 
-A 20 µm vessel is 10 voxels across at 2 µm and 1 voxel across at 20 µm. Choose
-`--d0`, `--epsilon` and `--iterations` (or `--d-min`) so that the network spans
-the field of view `shape * voxel_size`: under `voxel_size` the network is centred
-and clipped rather than scaled to fit.
+Only the sampling changes between the two, so the vessel calibre distribution of
+each result is that modality's — which is exactly what an unpaired
+image-to-image model learns as its output prior. A 20 µm vessel is 20 voxels
+across at 1 µm and 10 voxels across at 2 µm.
+
+Holding `shape` fixed instead would render the same network into two different
+fields of view. That is the mistake to avoid: at 20 µm/voxel a
+`512 × 512 × 140` volume covers 10 240 × 10 240 × 2800 µm, and the network above
+occupies 37 × 33 × 21 of its 36.7 million voxels.
+
+**One centreline serves a modality only while that modality can resolve it.**
+Every vessel thinner than a voxel is drawn at the one-voxel connectivity floor,
+so once most of the network is sub-voxel its calibre distribution collapses to a
+spike at 1 voxel instead of matching anything. Check before trusting a render:
+
+```python
+d = nodes[3][~np.isnan(nodes[3])] / voxel_size          # diameters in voxels
+print(np.percentile(d, [50, 90]), (d < 1.0).mean())     # ... and the sub-voxel fraction
+```
+
+For a modality whose voxel size approaches the network's finest vessels,
+generate a network for it — a larger `--d0`, or `--d-min` set to its smallest
+resolvable calibre — rather than rendering an existing one more coarsely.
+
+To target a fixed acquisition geometry instead, a `512 × 512 × 140` slab at
+2 µm say, choose `--d0`, `--epsilon` and `--iterations` (or `--d-min`) so that
+the network spans the field of view `shape * voxel_size`: under `voxel_size` the
+network is centred and clipped rather than scaled to fit.
 
 ---
 

--- a/computeVoxel.py
+++ b/computeVoxel.py
@@ -50,12 +50,23 @@ def normalise_axes(axes):
 
     Accepts indices (0, 1, 2) and names ("x", "y", "z"), in any mixture, and
     so also a bare string: "z" and "xy" are iterated character by character.
+    Booleans are rejected rather than read as the indices 0 and 1, so that a
+    boolean mask -- the natural numpy way to write "clip z" -- cannot be
+    misread as "clip x and y".
 
     Raises:
-        ValueError: on an axis that is neither a name nor an index in range.
+        ValueError: on an axis that is neither a name nor an index in range,
+            and on a selection that is not iterable.
     """
+    if isinstance(axes, (int, float)) or axes is None:
+        raise ValueError(
+            f"clip_axes must be a sequence of axes, got {axes!r}; write (2,) or \"z\"")
     out = set()
     for item in axes:
+        if isinstance(item, (bool, np.bool_)):
+            raise ValueError(
+                f"unknown axis {item!r}; use x, y, z or the indices 0, 1, 2, "
+                "not a boolean mask")
         if isinstance(item, str):
             name = item.strip().lower()
             if name not in AXES:
@@ -65,7 +76,7 @@ def normalise_axes(axes):
             continue
         try:
             index = int(item)
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, OverflowError):
             raise ValueError(
                 f"unknown axis {item!r}; use x, y, z or the indices 0, 1, 2") from None
         if index != item or index not in (0, 1, 2):

--- a/computeVoxel.py
+++ b/computeVoxel.py
@@ -20,12 +20,59 @@ axis independently to fill the volume with unscaled diameters. The isotropic
 fit can also be told to ignore some axes (`clip_axes`), so that a network
 fills a slab's two wide axes and is clipped along its depth, as a real imaging
 slab would clip it.
+
+A capsule sets only the voxels whose centres it contains, so a vessel thinner
+than a voxel contains no centre along much of its length and rasterises as a
+dotted line, breaking a connected tree into fragments. Every segment is
+therefore also drawn as a 26-connected digital line, which renders a sub-voxel
+vessel one voxel wide instead of dotted and leaves everything else untouched: a
+voxel on the line lies within sqrt(3)/2 of the centreline, so for a radius of
+0.866 voxels or more the line is already inside the capsule. Pass
+connect=False for the bare capsule rasterisation.
+
+Coordinates and diameters arrive in grammar units. The pipeline treats one
+grammar unit as one micrometre, so `voxel_size` is a physical voxel size in
+micrometres per voxel; see the Units section of the README.
 """
 
 import numpy as np
 
 
 FITS = ("isotropic", "voxel_size", "stretch")
+
+# Axis names accepted wherever an axis may be named rather than indexed.
+AXES = {"x": 0, "y": 1, "z": 2}
+
+
+def normalise_axes(axes):
+    """
+    Normalises an axis selection to a sorted tuple of distinct indices.
+
+    Accepts indices (0, 1, 2) and names ("x", "y", "z"), in any mixture, and
+    so also a bare string: "z" and "xy" are iterated character by character.
+
+    Raises:
+        ValueError: on an axis that is neither a name nor an index in range.
+    """
+    out = set()
+    for item in axes:
+        if isinstance(item, str):
+            name = item.strip().lower()
+            if name not in AXES:
+                raise ValueError(
+                    f"unknown axis {item!r}; use x, y, z or the indices 0, 1, 2")
+            out.add(AXES[name])
+            continue
+        try:
+            index = int(item)
+        except (TypeError, ValueError):
+            raise ValueError(
+                f"unknown axis {item!r}; use x, y, z or the indices 0, 1, 2") from None
+        if index != item or index not in (0, 1, 2):
+            raise ValueError(
+                f"unknown axis {item!r}; use x, y, z or the indices 0, 1, 2")
+        out.add(index)
+    return tuple(sorted(out))
 
 
 def fit_to_volume(data, tVol, fit="isotropic", voxel_size=None, margin=1.0, clip_axes=()):
@@ -36,11 +83,18 @@ def fit_to_volume(data, tVol, fit="isotropic", voxel_size=None, margin=1.0, clip
         data (ndarray): (4, N) array of x, y, z, diameter; NaN columns separate branches.
         tVol (sequence): volume shape (nx, ny, nz).
         fit (str): "isotropic" (default), "voxel_size" or "stretch".
-        voxel_size (float): grammar units per voxel, required when fit == "voxel_size".
+        voxel_size (float): grammar units (micrometres) per voxel, required
+            when fit == "voxel_size".
         margin (float): empty border, in voxels, kept around the network for the
             fitted modes.
-        clip_axes (sequence of int): axes (0, 1, 2) left out of the isotropic
-            fit; the network is centred on them and clipped by the rasteriser.
+        clip_axes (sequence): axes left out of the isotropic fit, as names
+            ("x", "y", "z") or indices (0, 1, 2); the network is centred on
+            them and clipped by the rasteriser. Only the isotropic fit reads
+            this: "voxel_size" and "stretch" ignore it. The default excludes no
+            axis, so the whole network is fitted; the command line and
+            main.generate_network default to clipping z instead, because their
+            default volume is an imaging slab. An unknown axis raises rather
+            than being ignored.
 
     Returns:
         tuple: (points, radii) with points a (3, N) array in voxel coordinates
@@ -54,6 +108,7 @@ def fit_to_volume(data, tVol, fit="isotropic", voxel_size=None, margin=1.0, clip
         raise ValueError("tVol must be three dimensions of at least 3 voxels")
     if fit not in FITS:
         raise ValueError(f"fit must be one of {FITS}, got {fit!r}")
+    clip = normalise_axes(clip_axes)
 
     xyz = data[:3]
     diam = data[3]
@@ -66,7 +121,7 @@ def fit_to_volume(data, tVol, fit="isotropic", voxel_size=None, margin=1.0, clip
 
     if fit == "isotropic":
         available = shape - 2.0 * margin
-        keep = [a for a in range(3) if a not in tuple(clip_axes)]
+        keep = [a for a in range(3) if a not in clip]
         if not keep:
             raise ValueError("clip_axes cannot exclude every axis")
         s = float(np.min((available / (extent + 2.0 * rmax))[keep]))
@@ -74,7 +129,8 @@ def fit_to_volume(data, tVol, fit="isotropic", voxel_size=None, margin=1.0, clip
         radius_scale = s
     elif fit == "voxel_size":
         if voxel_size is None or voxel_size <= 0:
-            raise ValueError("voxel_size must be a positive number of grammar units per voxel")
+            raise ValueError(
+                "voxel_size must be a positive number of grammar units (micrometres) per voxel")
         s = 1.0 / float(voxel_size)
         scale = np.full(3, s)
         radius_scale = s
@@ -118,10 +174,46 @@ def rasterise_capsule(volume, p0, p1, r0, r1):
     volume[lo[0]:hi[0] + 1, lo[1]:hi[1] + 1, lo[2]:hi[2] + 1][inside] = 1
 
 
-def rasterise_segments(points, radii, tVol):
+def rasterise_line(volume, p0, p1):
+    """
+    Sets a 26-connected chain of voxels along the segment from p0 to p1, so
+    that a vessel too thin to contain a voxel centre still renders as an
+    unbroken one-voxel path. Coordinates are voxel indices; voxels outside the
+    volume are dropped.
+
+    The segment is sampled finely enough that consecutive samples round to
+    voxels differing by at most one along each axis, which is what makes the
+    chain 26-connected. Every voxel it sets lies within sqrt(3)/2 of the
+    centreline, so for a radius of 0.866 voxels or more the capsule already
+    contains them and this adds nothing.
+    """
+    p0 = np.asarray(p0, dtype=float)
+    p1 = np.asarray(p1, dtype=float)
+    shape = np.asarray(volume.shape)
+    steps = max(int(np.ceil(np.max(np.abs(p1 - p0)) * 2.0)) + 1, 2)
+    t = np.linspace(0.0, 1.0, steps)
+    line = np.rint(p0[:, None] + t * (p1 - p0)[:, None]).astype(int)
+    inside = np.all((line >= 0) & (line < shape[:, None]), axis=0)
+    if not np.any(inside):
+        return
+    line = line[:, inside]
+    volume[line[0], line[1], line[2]] = 1
+
+
+def rasterise_segments(points, radii, tVol, connect=True):
     """
     Rasterises a polyline network. Consecutive non-NaN columns of `points`
     are joined by capsules; a NaN column breaks the chain.
+
+    Args:
+        points (ndarray): (3, N) array of voxel coordinates, NaN separated.
+        radii (ndarray): (N,) radii in voxels.
+        tVol (sequence): volume shape (nx, ny, nz).
+        connect (bool): also draw each segment as a 26-connected digital line,
+            so that a vessel thinner than a voxel renders one voxel wide rather
+            than as a dotted line and the rendered tree stays as connected as
+            the geometry is. False gives the bare capsule rasterisation, which
+            drops sub-voxel vessels in and out along their length.
 
     Returns:
         ndarray: uint8 volume of shape tVol with 1 inside vessels.
@@ -139,22 +231,36 @@ def rasterise_segments(points, radii, tVol):
             q, rq = previous
             if not np.array_equal(p, q):
                 rasterise_capsule(volume, q, p, rq, radii[i])
+                if connect:
+                    rasterise_line(volume, q, p)
         previous = (p, radii[i])
     return volume
 
 
-def process_network(data, tVol, fit="isotropic", voxel_size=None, margin=1.0, clip_axes=()):
+def process_network(data, tVol, fit="isotropic", voxel_size=None, margin=1.0, clip_axes=(),
+                    connect=True):
     """
     Maps a network into the volume and rasterises it.
 
     Args:
-        data (ndarray): (4, N) array of x, y, z, diameter with NaN separators.
+        data (ndarray): (4, N) array of x, y, z, diameter with NaN separators,
+            as returned by main.generate_network or read back from a saved
+            centreline with main.load_network.
         tVol (sequence): volume shape (nx, ny, nz).
-        fit, voxel_size, margin, clip_axes: see fit_to_volume.
+        fit, voxel_size, margin, clip_axes: see fit_to_volume. Note that
+            clip_axes defaults to no axis here, while the command line and
+            main.generate_network default to clipping z.
+        connect (bool): see rasterise_segments. Left true, a vessel too thin to
+            contain a voxel centre still renders as an unbroken one-voxel path.
 
     Returns:
         ndarray: uint8 volume with 1 inside vessels and 0 elsewhere.
+
+    A network clipped by the volume can still render as several pieces: a branch
+    that leaves a slab and re-enters it is two vessels in the image, as it would
+    be in a real acquisition. `clip_axes` and the volume shape control that;
+    `connect` does not.
     """
     points, radii = fit_to_volume(data, tVol, fit=fit, voxel_size=voxel_size, margin=margin,
                                   clip_axes=clip_axes)
-    return rasterise_segments(points, radii, tVol)
+    return rasterise_segments(points, radii, tVol, connect=connect)

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 """
-Command-line entry point: generates synthetic vascular networks and writes
-each one as a binary TIFF volume with a JSON sidecar recording how it was made.
+Command-line entry point: generates synthetic vascular networks and writes each
+one as a binary TIFF volume, a compressed centreline archive and a JSON sidecar
+recording how it was made.
 
     python main.py --count 5 --out ./output --seed 1
 
@@ -8,6 +9,23 @@ Every network is reproducible from its seed and the recorded parameters.
 The pipeline is: grammar string (vSystem.F) -> turtle interpretation
 (analyseGrammar) -> B-spline interpolation of stems (utils) -> mapping and
 capsule rasterisation into the volume (computeVoxel).
+
+The centreline archive is the source of truth for the geometry and the TIFF one
+rasterisation of it. Because computeVoxel maps grammar units to voxels at
+rasterisation time, the same saved centreline can be rendered at any voxel size
+-- once per imaging modality, say -- without regenerating the network and so
+without depending on generation being reproducible across versions:
+
+    from computeVoxel import process_network
+    from main import load_network
+
+    network = load_network("output/Lnet_i8_s1.npz")
+    volume = process_network(network["nodes"], (512, 512, 140),
+                             fit="voxel_size", voxel_size=2.0)
+
+Lengths and diameters are in grammar units, which the pipeline takes to be
+micrometres; see the Units section of the README. Each JSON sidecar records the
+convention it was written under in its "units" field.
 """
 import argparse
 import json
@@ -20,37 +38,60 @@ import tifffile
 
 import libGenerator
 from analyseGrammar import branching_turtle_to_coords
-from computeVoxel import FITS, process_network
+from computeVoxel import AXES, FITS, process_network
 from utils import interpolate_segments
 from vSystem import F
 
-AXES = {"x": 0, "y": 1, "z": 2}
+# The unit one grammar unit is taken to stand for. Diameters, segment lengths
+# and --voxel-size are all in this unit, so that --voxel-size is a modality's
+# physical voxel size. Recorded in every sidecar so a rescaled dataset declares
+# itself rather than being mistaken for the default.
+DEFAULT_UNITS = "um"
 
 
 def generate_network(niter, d0, properties, tVol, fit="isotropic", clip_axes=(2,),
                      voxel_size=None, subdivisions=3,
-                     direction=(0.0, 1.0, 0.0), perpendicular=(0.0, 0.0, 1.0)):
+                     direction=(0.0, 1.0, 0.0), perpendicular=(0.0, 0.0, 1.0),
+                     d_min=None, connect=True):
     """
     Generates one network and renders it into a volume.
 
     Args:
         niter (int): number of drawn generations.
-        d0 (float): root diameter, in grammar units.
+        d0 (float): root diameter, in grammar units (micrometres by convention).
         properties (dict): libGenerator parameters; missing keys take defaults.
         tVol (sequence): volume shape (nx, ny, nz).
-        fit, clip_axes, voxel_size: see computeVoxel.fit_to_volume.
+        fit, clip_axes, voxel_size: see computeVoxel.fit_to_volume. `clip_axes`
+            defaults to the depth axis here because the default volume is an
+            imaging slab, where computeVoxel defaults to clipping nothing; only
+            the isotropic fit reads it.
         subdivisions (int): B-spline sampling depth for braced stems.
         direction, perpendicular: initial turtle frame.
+        d_min (float or None): smallest drawn vessel diameter, in the same units
+            as d0; a branch terminates once it falls below it, so the tree stops
+            on whichever of `niter` and `d_min` comes first. None stops on
+            `niter` alone. It bounds the diameter a branch is drawn at, not the
+            diameter after a local anomaly: a stenosis still narrows a drawn
+            sub-segment by stenosis_factor.
+        connect (bool): see computeVoxel.rasterise_segments. Left true, a vessel
+            too thin to contain a voxel centre still renders as an unbroken
+            one-voxel path instead of a dotted line.
 
     Returns:
         tuple: (volume, program, nodes) with volume a uint8 array of 0 and 1,
-        program the grammar string and nodes the (4, N) interpolated centreline.
+        program the grammar string and nodes the (4, N) interpolated centreline
+        of x, y, z and diameter with NaN column separators.
+
+    `nodes` is the geometry in grammar units and independent of `tVol`, `fit`
+    and `voxel_size`: passing it back to computeVoxel.process_network with
+    different settings re-renders the same network at another resolution.
     """
     libGenerator.setProperties(properties)
-    program = F(niter, d0)
+    program = F(niter, d0, d_min)
     rows = branching_turtle_to_coords(program, d0, direction=direction, perpendicular=perpendicular)
     nodes = interpolate_segments(rows, subdivisions=subdivisions)
-    volume = process_network(nodes, tVol, fit=fit, voxel_size=voxel_size, clip_axes=clip_axes)
+    volume = process_network(nodes, tVol, fit=fit, voxel_size=voxel_size, clip_axes=clip_axes,
+                             connect=connect)
     return volume, program, nodes
 
 
@@ -61,6 +102,53 @@ def write_volume(path, volume):
     """
     stack = np.transpose(volume.astype(np.uint8) * 255, (2, 1, 0))
     tifffile.imwrite(path, stack, photometric="minisblack")
+
+
+def save_network(path, nodes, program=None, metadata=None):
+    """
+    Writes a centreline to a compressed .npz archive.
+
+    The archive holds the geometry in grammar units, so a reader can rasterise
+    it at any voxel size with computeVoxel.process_network instead of
+    regenerating the network or resampling a finished volume. It is a few
+    hundred kilobytes against hundreds of megabytes for a rendered volume.
+
+    Args:
+        path (str): destination; numpy appends '.npz' if it is missing.
+        nodes (ndarray): (4, N) array of x, y, z and diameter with NaN column
+            separators, as returned by generate_network.
+        program (str or None): the grammar string the network was drawn from.
+        metadata (dict or None): a JSON-serialisable record of how it was made,
+            including the unit its coordinates are in.
+
+    The stored arrays are exact, but the archive is a zip and its entries carry
+    a modification time, so two runs of the same seed produce equal arrays in
+    files that differ byte for byte.
+    """
+    arrays = {"nodes": np.asarray(nodes, dtype=float)}
+    if program is not None:
+        arrays["program"] = np.array(str(program))
+    if metadata is not None:
+        arrays["metadata"] = np.array(json.dumps(metadata))
+    np.savez_compressed(path, **arrays)
+
+
+def load_network(path):
+    """
+    Reads a centreline written by save_network.
+
+    Args:
+        path (str): the .npz archive.
+
+    Returns:
+        dict: "nodes" the (4, N) float array of x, y, z and diameter, "program"
+        the grammar string or None, and "metadata" the decoded record or None.
+    """
+    with np.load(path, allow_pickle=False) as handle:
+        nodes = np.asarray(handle["nodes"], dtype=float)
+        program = handle["program"].item() if "program" in handle.files else None
+        record = json.loads(handle["metadata"].item()) if "metadata" in handle.files else None
+    return {"nodes": nodes, "program": program, "metadata": record}
 
 
 def sample_parameters(args):
@@ -113,6 +201,10 @@ def build_parser():
     parser.add_argument("--d0", type=float, nargs=2, default=(20.0, 5.0), metavar=("MEAN", "STD"),
                         help="root diameter distribution in grammar units (default 20 5)")
     parser.add_argument("--d0-min", type=float, default=1.0, help="smallest accepted root diameter (default 1)")
+    parser.add_argument("--d-min", type=float, default=None, dest="d_min",
+                        help="smallest drawn vessel diameter in grammar units; a branch stops "
+                             "bifurcating once it falls below it (default: none, stop on "
+                             "--iterations alone). A stenosis still narrows a drawn sub-segment below it")
     parser.add_argument("--epsilon", type=float, nargs=2, default=(4.0, 10.0), metavar=("MIN", "MAX"),
                         help="length-to-diameter ratio range (default 4 10)")
     parser.add_argument("--randmarg", type=float, nargs=2, default=(0.1, 0.3), metavar=("MIN", "MAX"),
@@ -135,7 +227,15 @@ def build_parser():
     parser.add_argument("--clip-axes", type=parse_axes, default=(2,),
                         help="axes left out of the isotropic fit and clipped, e.g. 'z' or 'none' (default z)")
     parser.add_argument("--voxel-size", type=float, default=None,
-                        help="grammar units per voxel, for --fit voxel_size")
+                        help="grammar units per voxel, for --fit voxel_size; under the default "
+                             "unit convention this is the modality's voxel size in micrometres")
+    parser.add_argument("--units", default=DEFAULT_UNITS,
+                        help="physical unit one grammar unit stands for, recorded in the sidecar "
+                             f"(default {DEFAULT_UNITS}); it labels --d0, --d-min and --voxel-size "
+                             "and does not rescale anything")
+    parser.add_argument("--no-connect", action="store_false", dest="connect",
+                        help="rasterise bare capsules, so that a vessel thinner than a voxel "
+                             "renders as a dotted line rather than a one-voxel path")
     parser.add_argument("--subdivisions", type=int, default=3,
                         help="B-spline sampling depth for stems, 2^i points per span (default 3)")
     return parser
@@ -145,6 +245,8 @@ def main(argv=None):
     args = build_parser().parse_args(argv)
     if args.fit == "voxel_size" and args.voxel_size is None:
         raise SystemExit("--fit voxel_size requires --voxel-size")
+    if args.d_min is not None and args.d_min <= 0:
+        raise SystemExit("--d-min must be a positive diameter")
     base_seed = args.seed if args.seed is not None else random.SystemRandom().randrange(2 ** 31)
     os.makedirs(args.out, exist_ok=True)
     tVol = tuple(args.volume)
@@ -154,26 +256,36 @@ def main(argv=None):
         random.seed(seed)
         np.random.seed(seed % (2 ** 32))
         properties, d0, niter = sample_parameters(args)
-        volume, _, _ = generate_network(niter, d0, properties, tVol, fit=args.fit,
-                                        clip_axes=args.clip_axes, voxel_size=args.voxel_size,
-                                        subdivisions=args.subdivisions)
+        volume, program, nodes = generate_network(niter, d0, properties, tVol, fit=args.fit,
+                                                  clip_axes=args.clip_axes, voxel_size=args.voxel_size,
+                                                  subdivisions=args.subdivisions, d_min=args.d_min,
+                                                  connect=args.connect)
         stem = f"Lnet_i{niter}_s{seed}"
         write_volume(os.path.join(args.out, stem + ".tiff"), volume)
         record = {
             "seed": seed,
             "iterations": niter,
             "d0": d0,
+            "d_min": args.d_min,
             "properties": properties,
             "volume": list(tVol),
             "axis_order": "zyx",
+            "units": args.units,
             "fit": args.fit,
             "clip_axes": list(args.clip_axes),
+            "connect": args.connect,
             "voxel_size": args.voxel_size,
             "subdivisions": args.subdivisions,
         }
+        save_network(os.path.join(args.out, stem + ".npz"), nodes, program=program, metadata=record)
         with open(os.path.join(args.out, stem + ".json"), "w") as handle:
             json.dump(record, handle, indent=2)
-        print(f"{stem}.tiff: {niter} generations, d0 {d0:.1f}, vessel fraction {volume.mean() * 100:.2f}%")
+        calibre = ""
+        if args.fit == "voxel_size":
+            # the calibre a mis-scaled voxel size shows up in first
+            calibre = f", root diameter {d0 / args.voxel_size:.1f} voxels"
+        print(f"{stem}.tiff: {niter} generations, d0 {d0:.1f} {args.units}, "
+              f"vessel fraction {volume.mean() * 100:.2f}%{calibre}")
     return 0
 
 

--- a/main.py
+++ b/main.py
@@ -110,11 +110,14 @@ def save_network(path, nodes, program=None, metadata=None):
 
     The archive holds the geometry in grammar units, so a reader can rasterise
     it at any voxel size with computeVoxel.process_network instead of
-    regenerating the network or resampling a finished volume. It is a few
-    hundred kilobytes against hundreds of megabytes for a rendered volume.
+    regenerating the network or resampling a finished volume. It grows with the
+    number of drawn generations rather than with the volume: tens of kilobytes
+    at four generations and about seven megabytes at twelve, against 37 MB for
+    a 512 x 512 x 140 volume whatever the network inside it.
 
     Args:
-        path (str): destination; numpy appends '.npz' if it is missing.
+        path (str): destination; numpy appends '.npz' if it is missing, and
+            load_network accepts the path either way.
         nodes (ndarray): (4, N) array of x, y, z and diameter with NaN column
             separators, as returned by generate_network.
         program (str or None): the grammar string the network was drawn from.
@@ -125,7 +128,11 @@ def save_network(path, nodes, program=None, metadata=None):
     a modification time, so two runs of the same seed produce equal arrays in
     files that differ byte for byte.
     """
-    arrays = {"nodes": np.asarray(nodes, dtype=float)}
+    nodes = np.asarray(nodes, dtype=float)
+    if nodes.ndim != 2 or nodes.shape[0] != 4:
+        raise ValueError(
+            f"nodes must be a (4, N) array of x, y, z, diameter, got {nodes.shape}")
+    arrays = {"nodes": nodes}
     if program is not None:
         arrays["program"] = np.array(str(program))
     if metadata is not None:
@@ -138,12 +145,15 @@ def load_network(path):
     Reads a centreline written by save_network.
 
     Args:
-        path (str): the .npz archive.
+        path (str): the .npz archive, with or without its '.npz' suffix, since
+            save_network appends one to a path that lacks it.
 
     Returns:
         dict: "nodes" the (4, N) float array of x, y, z and diameter, "program"
         the grammar string or None, and "metadata" the decoded record or None.
     """
+    if not os.path.exists(path) and not path.endswith(".npz"):
+        path += ".npz"
     with np.load(path, allow_pickle=False) as handle:
         nodes = np.asarray(handle["nodes"], dtype=float)
         program = handle["program"].item() if "program" in handle.files else None
@@ -256,6 +266,10 @@ def main(argv=None):
         random.seed(seed)
         np.random.seed(seed % (2 ** 32))
         properties, d0, niter = sample_parameters(args)
+        if args.d_min is not None and d0 < args.d_min:
+            raise SystemExit(
+                f"--d-min {args.d_min:g} exceeds the root diameter {d0:.3g} sampled for seed "
+                f"{seed}, so the network would be empty; lower --d-min or raise --d0")
         volume, program, nodes = generate_network(niter, d0, properties, tVol, fit=args.fit,
                                                   clip_axes=args.clip_axes, voxel_size=args.voxel_size,
                                                   subdivisions=args.subdivisions, d_min=args.d_min,
@@ -277,9 +291,12 @@ def main(argv=None):
             "voxel_size": args.voxel_size,
             "subdivisions": args.subdivisions,
         }
-        save_network(os.path.join(args.out, stem + ".npz"), nodes, program=program, metadata=record)
         with open(os.path.join(args.out, stem + ".json"), "w") as handle:
             json.dump(record, handle, indent=2)
+        save_network(os.path.join(args.out, stem + ".npz"), nodes, program=program, metadata=record)
+        if not volume.any():
+            print(f"{stem}.tiff: warning: no vessel voxels; the network is outside the volume or "
+                  f"below its resolution", file=sys.stderr)
         calibre = ""
         if args.fit == "voxel_size":
             # the calibre a mis-scaled voxel size shows up in first

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vsystem"
-version = "3.0.0"
+version = "3.1.0"
 description = "Synthetic 3D vascular networks from stochastic parametric L-systems"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_vsystem.py
+++ b/tests/test_vsystem.py
@@ -11,6 +11,7 @@ import math
 import os
 import random
 import sys
+import tempfile
 import unittest
 
 import numpy as np
@@ -24,7 +25,9 @@ from libGenerator import setProperties, calBifurcation, getLength  # noqa: E402
 from vSystem import F, I, A, example_grammar  # noqa: E402
 from analyseGrammar import branching_turtle_to_coords, tokenise  # noqa: E402
 from utils import interpolate_segments, bspline, rotate_about  # noqa: E402
-from computeVoxel import process_network, rasterise_segments, fit_to_volume  # noqa: E402
+from computeVoxel import (process_network, rasterise_segments, fit_to_volume,  # noqa: E402
+                          normalise_axes, rasterise_line)
+from main import generate_network, load_network, save_network  # noqa: E402
 
 PROPERTIES = {"k": 3, "epsilon": 7.0, "randmarg": 0.2, "sigma": 5, "stochparams": True}
 
@@ -47,6 +50,35 @@ def final_row(program, d0=5.0):
     for row in branching_turtle_to_coords(program, d0):
         pass
     return row
+
+
+def connected_count(volume):
+    """
+    Returns (voxels set, voxels reachable from one of them under 26-connectivity),
+    so that the two are equal exactly when the rendered network is one piece.
+    """
+    set_voxels = np.argwhere(volume)
+    if len(set_voxels) == 0:
+        return 0, 0
+    shape = volume.shape
+    neighbourhood = [(dx, dy, dz)
+                     for dx in (-1, 0, 1) for dy in (-1, 0, 1) for dz in (-1, 0, 1)
+                     if (dx, dy, dz) != (0, 0, 0)]
+    seen = np.zeros(shape, dtype=bool)
+    start = tuple(int(v) for v in set_voxels[0])
+    seen[start] = True
+    stack = [start]
+    reached = 1
+    while stack:
+        x, y, z = stack.pop()
+        for dx, dy, dz in neighbourhood:
+            a, b, c = x + dx, y + dy, z + dz
+            if (0 <= a < shape[0] and 0 <= b < shape[1] and 0 <= c < shape[2]
+                    and volume[a, b, c] and not seen[a, b, c]):
+                seen[a, b, c] = True
+                reached += 1
+                stack.append((a, b, c))
+    return len(set_voxels), reached
 
 
 def angle_between(a, b):
@@ -353,6 +385,302 @@ class CommandLineTests(unittest.TestCase):
             for name in tiffs:
                 with open(os.path.join(first, name), "rb") as a, open(os.path.join(second, name), "rb") as b:
                     self.assertEqual(a.read(), b.read())
+                self.assertTrue(os.path.exists(os.path.join(first, name[:-5] + ".npz")))
+
+    def test_the_sidecar_and_centreline_alone_reproduce_the_written_volume(self):
+        import json
+        import tifffile
+        from main import main
+
+        args = ["--count", "1", "--seed", "7", "--volume", "64", "64", "32",
+                "--iterations", "4", "4", "--fit", "voxel_size", "--voxel-size", "6"]
+        with tempfile.TemporaryDirectory() as out:
+            self.assertEqual(main(args + ["--out", out]), 0)
+            stem = next(n[:-5] for n in os.listdir(out) if n.endswith(".tiff"))
+            with open(os.path.join(out, stem + ".json")) as handle:
+                record = json.load(handle)
+            self.assertEqual(record["units"], "um")
+            self.assertEqual(record["voxel_size"], 6.0)
+            self.assertIsNone(record["d_min"])
+
+            network = load_network(os.path.join(out, stem + ".npz"))
+            self.assertEqual(network["metadata"], record)
+            self.assertEqual(network["nodes"].shape[0], 4)
+            self.assertIn("f(", network["program"])
+            volume = process_network(network["nodes"], tuple(record["volume"]), fit=record["fit"],
+                                     voxel_size=record["voxel_size"], clip_axes=record["clip_axes"])
+            self.assertGreater(int(volume.sum()), 0)
+            written = tifffile.imread(os.path.join(out, stem + ".tiff"))
+            np.testing.assert_array_equal(np.transpose(volume, (2, 1, 0)) * 255, written)
+
+    def test_declared_units_and_d_min_reach_the_sidecar(self):
+        import json
+        from main import main
+
+        args = ["--count", "1", "--seed", "3", "--volume", "48", "48", "24",
+                "--iterations", "8", "8", "--units", "mm", "--d-min", "6"]
+        with tempfile.TemporaryDirectory() as out:
+            self.assertEqual(main(args + ["--out", out]), 0)
+            stem = next(n[:-5] for n in os.listdir(out) if n.endswith(".tiff"))
+            with open(os.path.join(out, stem + ".json")) as handle:
+                record = json.load(handle)
+            self.assertEqual(record["units"], "mm")
+            self.assertEqual(record["d_min"], 6.0)
+            nodes = load_network(os.path.join(out, stem + ".npz"))["nodes"]
+            self.assertGreaterEqual(float(np.nanmin(nodes[3])), 6.0 * 0.5 - 1e-9)  # a stenosis halves it
+
+    def test_a_non_positive_d_min_is_refused(self):
+        from main import main
+        with tempfile.TemporaryDirectory() as out:
+            with self.assertRaises(SystemExit):
+                main(["--count", "1", "--seed", "1", "--d-min", "0", "--out", out])
+
+
+class ConnectivityTests(unittest.TestCase):
+    """
+    A capsule sets only the voxels whose centres it contains, so a vessel
+    thinner than a voxel would rasterise as a dotted line and break the tree
+    into fragments. Each segment is therefore also drawn as a connected digital
+    line.
+    """
+
+    def setUp(self):
+        setProperties(PROPERTIES)
+
+    def test_a_sub_voxel_vessel_renders_as_one_unbroken_path(self):
+        points = np.array([[10.0, 60.0], [10.0, 55.0], [10.0, 52.0]])  # oblique, so it misses centres
+        radii = np.array([0.2, 0.2])
+        tVol = (72, 72, 72)
+        dotted = rasterise_segments(points, radii, tVol, connect=False)
+        joined = rasterise_segments(points, radii, tVol, connect=True)
+        self.assertGreater(int(joined.sum()), int(dotted.sum()))
+        total, reached = connected_count(joined)
+        self.assertEqual(total, reached)
+        self.assertGreater(total, 50)
+        dotted_total, dotted_reached = connected_count(dotted)
+        self.assertLess(dotted_reached, dotted_total)  # the bare capsules really are broken
+
+    def test_connecting_changes_nothing_once_a_vessel_fills_a_voxel(self):
+        # every voxel the line sets is within sqrt(3)/2 of the centreline, so at
+        # that radius and above the capsule already contains it
+        rng = np.random.default_rng(0)
+        tVol = (48, 48, 48)
+        for radius in (math.sqrt(3) / 2, 1.0, 5.0):
+            with self.subTest(radius=radius):
+                for _ in range(12):
+                    p0 = rng.uniform(15.0, 25.0, 3)
+                    points = np.stack([p0, p0 + rng.uniform(-12.0, 12.0, 3)], axis=1)
+                    radii = np.array([radius, radius])
+                    np.testing.assert_array_equal(
+                        rasterise_segments(points, radii, tVol, connect=False),
+                        rasterise_segments(points, radii, tVol, connect=True))
+
+    def test_a_rendered_network_is_one_piece_when_nothing_is_clipped(self):
+        for seed, tVol, niter in ((3, (96, 96, 96), 7), (11, (96, 96, 96), 7)):
+            with self.subTest(seed=seed):
+                seed_all(seed)
+                volume, _, _ = generate_network(niter, 20.0, PROPERTIES, tVol, clip_axes=())
+                total, reached = connected_count(volume)
+                self.assertGreater(total, 0)
+                self.assertEqual(total, reached)
+
+    def test_bare_capsules_break_the_same_network_apart(self):
+        seed_all(3)
+        tVol = (96, 96, 96)
+        volume, _, _ = generate_network(7, 20.0, PROPERTIES, tVol, clip_axes=(), connect=False)
+        total, reached = connected_count(volume)
+        self.assertGreater(total, 0)
+        self.assertLess(reached, total)
+
+    def test_the_line_stays_inside_the_volume(self):
+        volume = np.zeros((8, 8, 8), dtype=np.uint8)
+        rasterise_line(volume, (-40.0, -40.0, -40.0), (40.0, 40.0, 40.0))
+        self.assertGreater(int(volume.sum()), 0)
+        rasterise_line(volume, (-40.0, -40.0, -40.0), (-30.0, -30.0, -30.0))  # wholly outside
+        outside = np.zeros((8, 8, 8), dtype=np.uint8)
+        rasterise_line(outside, (100.0, 100.0, 100.0), (200.0, 200.0, 200.0))
+        self.assertEqual(int(outside.sum()), 0)
+
+    def test_a_clipped_slab_may_still_render_several_pieces(self):
+        # a branch that leaves a slab and re-enters is two vessels in the image,
+        # as it would be in a real acquisition; connect does not change that
+        seed_all(3)
+        volume, _, _ = generate_network(8, 20.0, PROPERTIES, (128, 128, 24), clip_axes=(2,))
+        total, reached = connected_count(volume)
+        self.assertGreater(total, 0)
+        self.assertLessEqual(reached, total)
+
+
+class CentrelinePersistenceTests(unittest.TestCase):
+    """
+    The saved centreline is the source of truth and the volume is derived from
+    it, so a reader can re-render a network at another resolution without
+    regenerating it.
+    """
+
+    def setUp(self):
+        setProperties(PROPERTIES)
+
+    def test_saved_nodes_re_render_the_generated_volume(self):
+        tVol = (64, 64, 32)
+        cases = (("isotropic", {"clip_axes": (2,)}),
+                 ("voxel_size", {"voxel_size": 6.0, "clip_axes": (2,)}))
+        for fit, settings in cases:
+            with self.subTest(fit=fit):
+                seed_all(17)
+                volume, program, nodes = generate_network(6, 20.0, PROPERTIES, tVol,
+                                                          fit=fit, **settings)
+                self.assertGreater(int(volume.sum()), 0)
+                with tempfile.TemporaryDirectory() as out:
+                    path = os.path.join(out, "net.npz")
+                    save_network(path, nodes, program=program, metadata={"units": "um"})
+                    network = load_network(path)
+                np.testing.assert_array_equal(network["nodes"], nodes)
+                self.assertEqual(network["program"], program)
+                self.assertEqual(network["metadata"], {"units": "um"})
+                again = process_network(network["nodes"], tVol, fit=fit, **settings)
+                self.assertTrue(np.array_equal(again, volume))
+
+    def test_a_centreline_saved_without_provenance_still_reads_back(self):
+        _, nodes, _ = generate(seed=8, niter=4)
+        with tempfile.TemporaryDirectory() as out:
+            path = os.path.join(out, "bare.npz")
+            save_network(path, nodes)
+            network = load_network(path)
+        np.testing.assert_array_equal(network["nodes"], nodes)
+        self.assertIsNone(network["program"])
+        self.assertIsNone(network["metadata"])
+
+    def test_nodes_do_not_depend_on_the_volume_they_were_rendered_into(self):
+        seed_all(9)
+        _, _, small = generate_network(5, 20.0, PROPERTIES, (64, 64, 32), fit="isotropic")
+        seed_all(9)
+        _, _, large = generate_network(5, 20.0, PROPERTIES, (256, 128, 64),
+                                       fit="voxel_size", voxel_size=3.0)
+        np.testing.assert_array_equal(small, large)
+
+    def test_a_centreline_is_far_smaller_than_the_volume_it_renders(self):
+        _, nodes, _ = generate(seed=6, niter=8)
+        tVol = (256, 256, 128)
+        with tempfile.TemporaryDirectory() as out:
+            path = os.path.join(out, "net.npz")
+            save_network(path, nodes)
+            self.assertLess(os.path.getsize(path), int(np.prod(tVol)) / 10)
+
+
+class UnitConventionTests(unittest.TestCase):
+    """
+    Grammar units are physical: one unit is one micrometre, so voxel_size is a
+    modality's voxel size and calibre in voxels goes as 1 / voxel_size.
+    """
+
+    def setUp(self):
+        setProperties(PROPERTIES)
+
+    def test_radii_in_voxels_scale_inversely_with_voxel_size(self):
+        _, nodes, _ = generate(seed=4, niter=6)
+        tVol = (64, 64, 32)
+        _, coarse = fit_to_volume(nodes, tVol, fit="voxel_size", voxel_size=8.0)
+        _, fine = fit_to_volume(nodes, tVol, fit="voxel_size", voxel_size=2.0)
+        self.assertGreater(float(np.nanmax(coarse)), 0.0)
+        np.testing.assert_allclose(fine, 4.0 * coarse)
+
+    def test_rasterised_calibre_scales_inversely_with_voxel_size(self):
+        diameter = 8.0  # grammar units; a single straight vessel along x
+        nodes = np.array([[20.0, 80.0], [15.0, 15.0], [15.0, 15.0], [diameter, diameter]])
+        tVol = (128, 48, 48)
+        areas = {}
+        for voxel_size in (1.0, 0.5):
+            volume = process_network(nodes, tVol, fit="voxel_size", voxel_size=voxel_size)
+            areas[voxel_size] = int(volume[tVol[0] // 2].sum())  # a mid-length cross-section
+            ideal = math.pi * (diameter / 2.0 / voxel_size) ** 2
+            self.assertAlmostEqual(areas[voxel_size] / ideal, 1.0, delta=0.05)
+        self.assertAlmostEqual(math.sqrt(areas[0.5] / areas[1.0]), 2.0, delta=0.05)
+
+    def test_a_non_positive_voxel_size_is_rejected(self):
+        _, nodes, _ = generate(seed=4, niter=4)
+        for voxel_size in (None, 0.0, -1.0):
+            with self.subTest(voxel_size=voxel_size):
+                with self.assertRaises(ValueError):
+                    fit_to_volume(nodes, (64, 64, 32), fit="voxel_size", voxel_size=voxel_size)
+
+
+class AxisSelectionTests(unittest.TestCase):
+    def setUp(self):
+        setProperties(PROPERTIES)
+
+    def test_names_indices_and_bare_strings_all_name_axes(self):
+        self.assertEqual(normalise_axes(()), ())
+        self.assertEqual(normalise_axes("z"), (2,))
+        self.assertEqual(normalise_axes(("Z", 0, "x")), (0, 2))
+        self.assertEqual(normalise_axes([1, 1]), (1,))
+        self.assertEqual(normalise_axes(np.array([2, 0])), (0, 2))
+
+    def test_an_unknown_axis_raises_rather_than_being_ignored(self):
+        for axes in (("w",), ("",), (3,), (-1,), (1.5,), (None,)):
+            with self.subTest(axes=axes):
+                with self.assertRaises(ValueError):
+                    normalise_axes(axes)
+
+    def test_a_named_clip_axis_clips(self):
+        _, nodes, _ = generate(seed=2, niter=5)
+        tVol = (100, 80, 20)
+        named = fit_to_volume(nodes, tVol, fit="isotropic", clip_axes=("z",))
+        indexed = fit_to_volume(nodes, tVol, fit="isotropic", clip_axes=(2,))
+        unclipped = fit_to_volume(nodes, tVol, fit="isotropic", clip_axes=())
+        for a, b in zip(named, indexed):
+            np.testing.assert_array_equal(a, b)
+        self.assertFalse(np.allclose(named[1], unclipped[1]))
+        with self.assertRaises(ValueError):
+            fit_to_volume(nodes, tVol, fit="isotropic", clip_axes=("depth",))
+
+
+class StoppingCriterionTests(unittest.TestCase):
+    """`d_min` stops a branch once its diameter falls below a resolvable calibre."""
+
+    def test_no_d_min_leaves_the_grammar_unchanged(self):
+        setProperties(PROPERTIES)
+        seed_all(5)
+        without = F(6, 20.0)
+        seed_all(5)
+        explicit_none = F(6, 20.0, d_min=None)
+        self.assertEqual(without, explicit_none)
+
+    def test_no_vessel_is_drawn_below_d_min(self):
+        setProperties({**PROPERTIES, "aneurysm_prob": 0.0, "stenosis_prob": 0.0})
+        seed_all(5)
+        unlimited = F(12, 20.0)
+        seed_all(5)
+        limited = F(12, 20.0, d_min=10.0)
+        drawn = [p[1] for c, p in tokenise(limited) if c == "f" and len(p) > 1]
+        self.assertTrue(drawn)
+        self.assertGreaterEqual(min(drawn), 10.0)
+        self.assertLess(len(limited), len(unlimited))
+
+    def test_d_min_reaches_the_generation_count_it_implies(self):
+        # deterministic daughters shrink by 2^(-1/k) a generation, so the last
+        # drawn calibre lies in [d_min, d_min * 2^(1/k)) and the depth is about
+        # log(d0 / d_min) / log(2^(1/k)).
+        k = PROPERTIES["k"]
+        setProperties({**PROPERTIES, "stochparams": False,
+                       "aneurysm_prob": 0.0, "stenosis_prob": 0.0})
+        seed_all(0)
+        d0, d_min = 20.0, 3.0
+        diameters = [p[1] for c, p in tokenise(F(100, d0, d_min=d_min)) if c == "f" and len(p) > 1]
+        self.assertGreaterEqual(min(diameters), d_min)
+        self.assertLess(min(diameters), d_min * 2 ** (1.0 / k))
+        depth = math.log(d0 / min(diameters)) / math.log(2 ** (1.0 / k))
+        self.assertAlmostEqual(depth, math.floor(math.log(d0 / d_min) / math.log(2 ** (1.0 / k))),
+                               delta=1.0)
+
+    def test_generate_network_honours_d_min(self):
+        setProperties(PROPERTIES)
+        seed_all(13)
+        _, program, nodes = generate_network(12, 20.0, {**PROPERTIES, "aneurysm_prob": 0.0,
+                                                        "stenosis_prob": 0.0},
+                                             (64, 64, 32), d_min=8.0)
+        self.assertGreaterEqual(float(np.nanmin(nodes[3])), 8.0 - 1e-9)
+        self.assertIn("f(", program)
 
 
 class DeterminismTests(unittest.TestCase):

--- a/tests/test_vsystem.py
+++ b/tests/test_vsystem.py
@@ -597,6 +597,31 @@ class UnitConventionTests(unittest.TestCase):
             self.assertAlmostEqual(areas[voxel_size] / ideal, 1.0, delta=0.05)
         self.assertAlmostEqual(math.sqrt(areas[0.5] / areas[1.0]), 2.0, delta=0.05)
 
+    def test_holding_the_field_of_view_fixed_changes_only_the_sampling(self):
+        # the README renders one centreline per modality by deriving the volume
+        # shape from voxel_size, so that shape * voxel_size stays put; only then
+        # is the rendered calibre distribution that modality's
+        _, nodes, _ = generate(seed=4, niter=7)
+        extent = np.nanmax(nodes[:3], axis=1) - np.nanmin(nodes[:3], axis=1)
+        fills = {}
+        for voxel_size in (2.0, 1.0):
+            shape = np.ceil(extent / voxel_size).astype(int) + 8
+            volume = process_network(nodes, shape, fit="voxel_size", voxel_size=voxel_size)
+            fills[voxel_size] = volume.mean()
+            self.assertGreater(int(volume.sum()), 0)
+        # halving the voxel size doubles every calibre in voxels but renders the
+        # same physical object, so the occupied fraction barely moves
+        self.assertAlmostEqual(fills[1.0] / fills[2.0], 1.0, delta=0.25)
+
+    def test_a_fixed_shape_across_voxel_sizes_changes_the_field_of_view(self):
+        # the mistake the README warns against: the coarse render is then a
+        # near-empty corner of a volume covering a far larger field of view
+        _, nodes, _ = generate(seed=4, niter=7)
+        shape = (256, 256, 70)
+        fine = process_network(nodes, shape, fit="voxel_size", voxel_size=2.0)
+        coarse = process_network(nodes, shape, fit="voxel_size", voxel_size=20.0)
+        self.assertGreater(fine.mean(), 20 * coarse.mean())
+
     def test_a_non_positive_voxel_size_is_rejected(self):
         _, nodes, _ = generate(seed=4, niter=4)
         for voxel_size in (None, 0.0, -1.0):

--- a/tests/test_vsystem.py
+++ b/tests/test_vsystem.py
@@ -432,8 +432,55 @@ class CommandLineTests(unittest.TestCase):
     def test_a_non_positive_d_min_is_refused(self):
         from main import main
         with tempfile.TemporaryDirectory() as out:
-            with self.assertRaises(SystemExit):
+            with self.assertRaises(SystemExit) as caught:
                 main(["--count", "1", "--seed", "1", "--d-min", "0", "--out", out])
+            self.assertIn("--d-min", str(caught.exception))
+
+    def test_a_d_min_above_the_root_diameter_is_refused_rather_than_left_blank(self):
+        from main import main
+        with tempfile.TemporaryDirectory() as out:
+            with self.assertRaises(SystemExit) as caught:
+                main(["--count", "1", "--seed", "5", "--volume", "64", "64", "32",
+                      "--d-min", "500", "--out", out])
+            self.assertIn("empty", str(caught.exception))
+            self.assertEqual([f for f in os.listdir(out) if f.endswith(".tiff")], [])
+
+    def test_the_isotropic_default_also_round_trips_through_its_sidecar(self):
+        # the voxel_size round trip ignores clip_axes; this one depends on it
+        import json
+        import tifffile
+        from main import main
+
+        args = ["--count", "1", "--seed", "9", "--volume", "64", "56", "24", "--iterations", "5", "5"]
+        with tempfile.TemporaryDirectory() as out:
+            self.assertEqual(main(args + ["--out", out]), 0)
+            stem = next(n[:-5] for n in os.listdir(out) if n.endswith(".tiff"))
+            with open(os.path.join(out, stem + ".json")) as handle:
+                record = json.load(handle)
+            self.assertEqual(record["fit"], "isotropic")
+            self.assertEqual(record["clip_axes"], [2])
+            self.assertTrue(record["connect"])
+            nodes = load_network(os.path.join(out, stem + ".npz"))["nodes"]
+            volume = process_network(nodes, tuple(record["volume"]), fit=record["fit"],
+                                     clip_axes=record["clip_axes"], connect=record["connect"])
+            written = tifffile.imread(os.path.join(out, stem + ".tiff"))
+            np.testing.assert_array_equal(np.transpose(volume, (2, 1, 0)) * 255, written)
+
+    def test_no_connect_reaches_the_rasteriser_and_the_sidecar(self):
+        import json
+        import tifffile
+        from main import main
+
+        args = ["--count", "1", "--seed", "9", "--volume", "64", "56", "24", "--iterations", "5", "5"]
+        with tempfile.TemporaryDirectory() as joined, tempfile.TemporaryDirectory() as bare:
+            self.assertEqual(main(args + ["--out", joined]), 0)
+            self.assertEqual(main(args + ["--no-connect", "--out", bare]), 0)
+            stem = next(n[:-5] for n in os.listdir(bare) if n.endswith(".tiff"))
+            with open(os.path.join(bare, stem + ".json")) as handle:
+                self.assertFalse(json.load(handle)["connect"])
+            a = tifffile.imread(os.path.join(joined, stem + ".tiff"))
+            b = tifffile.imread(os.path.join(bare, stem + ".tiff"))
+            self.assertGreater(int((a > 0).sum()), int((b > 0).sum()))
 
 
 class ConnectivityTests(unittest.TestCase):
@@ -501,14 +548,14 @@ class ConnectivityTests(unittest.TestCase):
         rasterise_line(outside, (100.0, 100.0, 100.0), (200.0, 200.0, 200.0))
         self.assertEqual(int(outside.sum()), 0)
 
-    def test_a_clipped_slab_may_still_render_several_pieces(self):
+    def test_a_clipped_slab_still_renders_several_pieces(self):
         # a branch that leaves a slab and re-enters is two vessels in the image,
         # as it would be in a real acquisition; connect does not change that
         seed_all(3)
         volume, _, _ = generate_network(8, 20.0, PROPERTIES, (128, 128, 24), clip_axes=(2,))
         total, reached = connected_count(volume)
         self.assertGreater(total, 0)
-        self.assertLessEqual(reached, total)
+        self.assertLess(reached, total)
 
 
 class CentrelinePersistenceTests(unittest.TestCase):
@@ -541,6 +588,22 @@ class CentrelinePersistenceTests(unittest.TestCase):
                 again = process_network(network["nodes"], tVol, fit=fit, **settings)
                 self.assertTrue(np.array_equal(again, volume))
 
+    def test_a_path_without_the_suffix_saves_and_loads(self):
+        _, nodes, _ = generate(seed=8, niter=4)
+        with tempfile.TemporaryDirectory() as out:
+            path = os.path.join(out, "bare")
+            save_network(path, nodes)
+            self.assertEqual(os.listdir(out), ["bare.npz"])   # numpy appends it on write
+            np.testing.assert_array_equal(load_network(path)["nodes"], nodes)
+            np.testing.assert_array_equal(load_network(path + ".npz")["nodes"], nodes)
+
+    def test_a_centreline_of_the_wrong_shape_is_refused(self):
+        with tempfile.TemporaryDirectory() as out:
+            for bad in (np.zeros((7, 4)), np.zeros(4), np.zeros((3, 5))):
+                with self.subTest(shape=bad.shape):
+                    with self.assertRaises(ValueError):
+                        save_network(os.path.join(out, "bad.npz"), bad)
+
     def test_a_centreline_saved_without_provenance_still_reads_back(self):
         _, nodes, _ = generate(seed=8, niter=4)
         with tempfile.TemporaryDirectory() as out:
@@ -559,13 +622,17 @@ class CentrelinePersistenceTests(unittest.TestCase):
                                        fit="voxel_size", voxel_size=3.0)
         np.testing.assert_array_equal(small, large)
 
-    def test_a_centreline_is_far_smaller_than_the_volume_it_renders(self):
-        _, nodes, _ = generate(seed=6, niter=8)
-        tVol = (256, 256, 128)
-        with tempfile.TemporaryDirectory() as out:
-            path = os.path.join(out, "net.npz")
-            save_network(path, nodes)
-            self.assertLess(os.path.getsize(path), int(np.prod(tVol)) / 10)
+    def test_a_centreline_is_smaller_than_the_volume_it_renders(self):
+        # the archive grows with the generation count, the volume does not, so
+        # check the deepest tree the command line will draw, not just a shallow one
+        tVol = (512, 512, 140)
+        for niter in (4, 12):
+            with self.subTest(niter=niter):
+                _, nodes, _ = generate(seed=6, niter=niter, tVol=(32, 32, 32))
+                with tempfile.TemporaryDirectory() as out:
+                    path = os.path.join(out, "net.npz")
+                    save_network(path, nodes)
+                    self.assertLess(os.path.getsize(path), int(np.prod(tVol)))
 
 
 class UnitConventionTests(unittest.TestCase):
@@ -622,6 +689,18 @@ class UnitConventionTests(unittest.TestCase):
         coarse = process_network(nodes, shape, fit="voxel_size", voxel_size=20.0)
         self.assertGreater(fine.mean(), 20 * coarse.mean())
 
+    def test_the_calibre_law_stops_at_the_one_voxel_floor(self):
+        # 1/voxel_size holds for what the grid can resolve; below that the
+        # connectivity floor renders every vessel one voxel wide instead
+        diameter = 8.0
+        nodes = np.array([[20.0, 80.0], [15.0, 15.0], [15.0, 15.0], [diameter, diameter]])
+        tVol = (128, 48, 48)
+        coarse = process_network(nodes, tVol, fit="voxel_size", voxel_size=64.0)
+        self.assertGreater(int(coarse.sum()), 0)                      # not dropped
+        mid = coarse[tVol[0] // 2]
+        self.assertLessEqual(int(mid.sum()), 2)                       # but not scaled either
+        self.assertLess(diameter / 64.0, 1.0)                         # it is sub-voxel
+
     def test_a_non_positive_voxel_size_is_rejected(self):
         _, nodes, _ = generate(seed=4, niter=4)
         for voxel_size in (None, 0.0, -1.0):
@@ -641,8 +720,23 @@ class AxisSelectionTests(unittest.TestCase):
         self.assertEqual(normalise_axes([1, 1]), (1,))
         self.assertEqual(normalise_axes(np.array([2, 0])), (0, 2))
 
+    def test_a_boolean_mask_is_refused_rather_than_read_as_indices(self):
+        # [False, False, True] means "clip z" to a reader, but bool is an int
+        # subclass, so read as indices it would silently mean "clip x and y"
+        for axes in ([False, False, True], (True,), np.array([False, False, True])):
+            with self.subTest(axes=axes):
+                with self.assertRaises(ValueError):
+                    normalise_axes(axes)
+
+    def test_a_bare_axis_that_is_not_a_sequence_is_refused(self):
+        for axes in (2, 2.0, None):
+            with self.subTest(axes=axes):
+                with self.assertRaises(ValueError):
+                    normalise_axes(axes)
+
     def test_an_unknown_axis_raises_rather_than_being_ignored(self):
-        for axes in (("w",), ("",), (3,), (-1,), (1.5,), (None,)):
+        for axes in (("w",), ("",), (3,), (-1,), (1.5,), (None,),
+                     (float("inf"),), (float("nan"),)):
             with self.subTest(axes=axes):
                 with self.assertRaises(ValueError):
                     normalise_axes(axes)

--- a/vSystem.py
+++ b/vSystem.py
@@ -156,9 +156,12 @@ def R(n, d0, d_min=None):
     if n <= 0 or (d_min is not None and d0 < d_min):
         return "R"
     p = calBifurcation(d0)
+    # the trunk carries on at d2, so it is subject to d_min like any other branch
+    trunk = ""
+    if d_min is None or p["d2"] >= d_min:
+        trunk = _segment(p["co"] / 2.0, p["d2"]) + B(n - 1, p["d2"], d_min)
     return (_segment(p["co"] / 3.0) + C(d0) + C(d0) + C(d0)
-            + "[" + B(n - 1, p["d1"], d_min) + "]"
-            + _segment(p["co"] / 2.0, p["d2"]) + B(n - 1, p["d2"], d_min))
+            + "[" + B(n - 1, p["d1"], d_min) + "]" + trunk)
 
 
 def I(n, d0, d_min=None):

--- a/vSystem.py
+++ b/vSystem.py
@@ -14,6 +14,16 @@ the source are documented on each rule: stems are always drawn, so an
 iteration count is a count of drawn generations; the length margin is
 relative (see libGenerator); and anomalies are drawn per sub-segment with
 configurable probabilities instead of being written into a grammar by hand.
+
+The recursive rules also accept `d_min`, a smallest drawn diameter in grammar
+units (micrometres by the convention of the README). A branch terminates as
+soon as its diameter falls below it, so no vessel thinner than a modality's
+smallest resolvable calibre is written into the grammar. Left at None the
+rules stop on the iteration count alone; with both set, whichever comes first
+wins. Diameters fall by 2^(-1/k) per generation, so the iteration count that
+reaches d_min from d0 is about log(d0/d_min) / log(2^(1/k)). It bounds the
+diameter a branch is drawn at, not the diameter after a local anomaly: a
+stenosis still narrows a drawn sub-segment by stenosis_factor.
 """
 import random
 
@@ -31,7 +41,7 @@ def _segment(length, diameter=None):
     return "f(" + _num(length) + "," + _num(diameter) + ")"
 
 
-def F(n, d0):
+def F(n, d0, d_min=None):
     """
     Bifurcating tree: a stem, then two daughters turned by the Zamir angles
     on opposite sides of the parent, each followed by a roll of the
@@ -39,14 +49,20 @@ def F(n, d0):
 
     Source: F(d0) -> {S(d0)} [+(th1) /(70) F(d1)] [-(th2) /(70) F(d2)].
     The roll angle is the roll_angle property (70 degrees by default).
+
+    Args:
+        n (int): remaining generations.
+        d0 (float): diameter of this branch, in grammar units.
+        d_min (float or None): smallest drawn diameter; a branch thinner than
+            this terminates without drawing its stem.
     """
-    if n <= 0:
+    if n <= 0 or (d_min is not None and d0 < d_min):
         return "F"
     p = calBifurcation(d0)
     roll = _num(lg.roll_angle)
     return ("{" + S(d0) + "}"
-            + "[+(" + _num(p["th1"]) + ")/(" + roll + ")" + F(n - 1, p["d1"]) + "]"
-            + "[-(" + _num(p["th2"]) + ")/(" + roll + ")" + F(n - 1, p["d2"]) + "]")
+            + "[+(" + _num(p["th1"]) + ")/(" + roll + ")" + F(n - 1, p["d1"], d_min) + "]"
+            + "[-(" + _num(p["th2"]) + ")/(" + roll + ")" + F(n - 1, p["d2"], d_min) + "]")
 
 
 def S(d0):
@@ -106,55 +122,55 @@ def C(d0, divisor=7.0, bend=18.0):
     return _segment(getLength(d0) / divisor, d0) + "-(" + _num(bend) + ")"
 
 
-def A(n, d0):
+def A(n, d0, d_min=None):
     """
     Bifurcating sub-tree without rolls, used by the side-branch grammar.
 
     Source: A(d0) -> S(d0) [+(th1) A(d1)] [-(th2) A(d2)].
     """
-    if n <= 0:
+    if n <= 0 or (d_min is not None and d0 < d_min):
         return "A"
     p = calBifurcation(d0)
     return ("{" + S(d0) + "}"
-            + "[+(" + _num(p["th1"]) + ")" + A(n - 1, p["d1"]) + "]"
-            + "[-(" + _num(p["th2"]) + ")" + A(n - 1, p["d2"]) + "]")
+            + "[+(" + _num(p["th1"]) + ")" + A(n - 1, p["d1"], d_min) + "]"
+            + "[-(" + _num(p["th2"]) + ")" + A(n - 1, p["d2"], d_min) + "]")
 
 
-def B(n, d0):
+def B(n, d0, d_min=None):
     """
     Three curving sub-segments, a roll of 90 degrees, then a sub-tree.
 
     Source: B(d0) -> D(d0) D(d0) D(d0) /(90) A(d0).
     """
-    if n <= 0:
+    if n <= 0 or (d_min is not None and d0 < d_min):
         return "B"
-    return C(d0) + C(d0) + C(d0) + "/(90.0)" + A(n - 1, d0)
+    return C(d0) + C(d0) + C(d0) + "/(90.0)" + A(n - 1, d0, d_min)
 
 
-def R(n, d0):
+def R(n, d0, d_min=None):
     """
     A segment with a side branch and a continuing trunk.
 
     Source: R(d0) -> f('co/3') D D D [B(d1)] f('co/2', d2) B(d2).
     """
-    if n <= 0:
+    if n <= 0 or (d_min is not None and d0 < d_min):
         return "R"
     p = calBifurcation(d0)
     return (_segment(p["co"] / 3.0) + C(d0) + C(d0) + C(d0)
-            + "[" + B(n - 1, p["d1"]) + "]"
-            + _segment(p["co"] / 2.0, p["d2"]) + B(n - 1, p["d2"]))
+            + "[" + B(n - 1, p["d1"], d_min) + "]"
+            + _segment(p["co"] / 2.0, p["d2"]) + B(n - 1, p["d2"], d_min))
 
 
-def I(n, d0):
+def I(n, d0, d_min=None):
     """
     Initial segment followed by one side branch.
 
     Source: I(d0) -> f('co/3', d0) +(25) [R(d0)].
     """
-    if n <= 0:
+    if n <= 0 or (d_min is not None and d0 < d_min):
         return "I"
     return (_segment(getLength(d0) / 3.0, d0) + "+(" + _num(lg.stem_angle) + ")"
-            + "[" + R(n - 1, d0) + "]")
+            + "[" + R(n - 1, d0, d_min) + "]")
 
 
 def example_grammar(n, d0):


### PR DESCRIPTION
Makes the centreline the source of truth for a generated network, states the physical unit its coordinates are in, and stops the rasteriser from breaking vessels it cannot fit a voxel centre inside.

## Persist the centreline

Each network is now written as three files sharing a stem, the new one being `Lnet_i<generations>_s<seed>.npz` holding `nodes` — the (4, N) array of x, y, z and diameter with NaN column separators — alongside the grammar string and the sidecar record. `main` gains `save_network` and `load_network` for it.

This makes the TIFF a derived artefact. Because `computeVoxel` maps grammar units to voxels at rasterisation time, a reader can call `process_network` on the saved nodes at any voxel size without regenerating the network, and so without depending on generation being reproducible across parameter changes. The archive grows with the generation count rather than the volume: tens of kilobytes at four generations, about seven megabytes at twelve, against 37 MB for a `512 × 512 × 140` volume whatever the network inside it.

## Pin the unit convention

One grammar unit is one micrometre. The README states it, `--units` records it in every sidecar so a rescaled dataset declares itself, and `--voxel-size` is therefore a modality's physical voxel size. Rendering one saved centreline once per modality gives each dataset that modality's vessel calibre distribution; resampling a finished binary volume cannot, because it destroys vessels a voxel wide.

The law has a limit, now documented: `1 / voxel_size` holds down to the grid, and a vessel below one voxel across is drawn at the connectivity floor rather than scaled.

## Keep thin vessels connected

A capsule sets only the voxels whose centres it contains, so a vessel thinner than a voxel rasterised as a dotted line and a connected tree fell apart into fragments. With default parameters more than a third of the centreline is that thin and a single tree rendered as over a hundred pieces.

Every segment is now also drawn as a 26-connected digital line. This is not a dilation: every voxel it sets lies within `sqrt(3)/2` of the centreline, so at a radius of 0.866 voxels or more it is already inside the capsule and calibre is untouched.

| | components | vessel fraction |
| --- | --- | --- |
| before, `--clip-axes none` | 117 | 0.01% |
| after, `--clip-axes none` | **1** | 0.04% |
| before, `--clip-axes z` | 67 | 0.22% |
| after, `--clip-axes z` | 11 | 0.23% |

The residual pieces under `--clip-axes z` are not a defect: a branch that leaves a slab and re-enters it is two vessels in the image, as it would be in a real acquisition.

**This changes rendered volumes for a given seed.** `--no-connect` restores the previous rasterisation.

## Also in

- `vSystem`'s recursive rules take an optional `d_min`, exposed as `--d-min`, stopping a branch once its diameter falls below a modality's smallest resolvable calibre. It bounds the diameter a branch is drawn at, not the diameter after a local anomaly.
- `computeVoxel.normalise_axes` lets `clip_axes` name axes as well as index them. `clip_axes=("z",)` was previously compared against integers and so was silently a no-op; an axis that is neither a name nor an index in range now raises, as does a boolean mask, which read as indices would mean the opposite of what it says.
- `clip_axes` is read by the isotropic fit alone, and the library keeps its default of clipping nothing while the command line clips z because its default volume is an imaging slab. Both defaults are now documented rather than merely divergent.
- A run whose sampled root diameter falls below `--d-min` stopped at the axiom and wrote a blank volume with a zero exit status; it now fails with a message naming both diameters, and any volume that renders empty for another reason warns on stderr.
- `save_network` rejects an array that is not (4, N), and `load_network` accepts a path with or without its `.npz` suffix, which `save_network` appends.

## Behaviour changes

Everything above is additive except three things worth calling out: rendered volumes differ for a given seed unless `--no-connect` is passed; the progress line now names the unit and, under `--fit voxel_size`, the root diameter in voxels; and `clip_axes` validation now raises on values it previously ignored.

## Verification

65 tests, pyflakes clean on 3.10–3.12. The acceptance criteria are pinned rather than asserted: a saved centreline re-renders the volume it was generated with under both fits, a sidecar plus its `.npz` reproduces the written TIFF exactly, calibre in voxels scales as `1 / voxel_size` while the field of view is held fixed, an unclipped network renders as one 26-connected component, bare capsules do not, and connecting changes nothing once a vessel fills a voxel.