### PR TITLE
Draw thin vessels as face-connected chains rather than corner-connected lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,10 @@ The alphabet is the dissertation's. `f(l, d)` moves by `l` along the direction
 vector and records diameter `d`; `+(θ)` and `-(θ)` rotate the direction about the
 perpendicular vector; `/(β)` and `*(β)` rotate the perpendicular about the
 direction; `[` and `]` push and pop the whole state; `{` and `}` delimit a stem
-that is interpolated as one smooth curve. An operand left out takes its default:
+that is interpolated as one smooth curve. A `[` inside a stem pins the stem at
+the branch point — the part before it and the part after it are interpolated as
+separate curves that meet exactly there — so a branch may leave a stem midway
+without disconnecting the centreline. An operand left out takes its default:
 the segment length for the current diameter, the Zamir angle θ1, or the roll angle.
 
 | Rule | Production | Source |

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ obey Murray's law and bifurcation angles follow Zamir's minimum-volume rule.
 3. **Interpolation** (`utils.py`): each stem is smoothed with a cubic B-spline.
 4. **Voxelisation** (`computeVoxel.py`): the network is mapped into the volume
    with a single isotropic scale factor and every segment is drawn as a tapered
-   capsule, so calibre and bifurcation angles survive into the image, plus a
-   connected digital line, so a vessel thinner than a voxel stays unbroken.
+   capsule, so calibre and bifurcation angles survive into the image, plus the
+   face-connected chain of voxels it passes through, so a vessel thinner than a
+   voxel stays unbroken.
 
 Steps 1–3 produce the **centreline**, which is saved alongside the volume. The
 centreline is the source of truth for the geometry and the TIFF is one
@@ -96,7 +97,10 @@ Each network is written as three files sharing the stem
 | `.json` | the seed, the unit convention and every parameter used |
 
 Network *i* of a run uses `seed + i`, and the same seed and parameters reproduce
-the same volume. The centreline archive grows with the number of drawn
+the same volume. The default volume is an imaging slab, fitted in x and y and
+clipped in z, so vessels leave and re-enter it and a deep network renders as
+several pieces; see *Connectivity* below for what that means and how to change
+it. The centreline archive grows with the number of drawn
 generations rather than with the volume — tens of kilobytes at four generations
 and about seven megabytes at twelve, against 37 MB for a `512 × 512 × 140`
 volume whatever the network inside it. Its arrays are exact; being a zip, its
@@ -140,19 +144,37 @@ a voxel contains no centre along much of its length, so on its own it rasterises
 as a dotted line and a connected tree falls apart into fragments — with the
 default parameters, more than a third of the centreline is that thin and a
 single tree renders as dozens of pieces. Every segment is therefore also drawn
-as a 26-connected digital line, which renders a sub-voxel vessel one voxel wide
-instead of dotted. It is not a dilation: every voxel the line sets lies within
+as the chain of voxels it passes through, walked one face at a time
+(Amanatides & Woo, 1987), which renders a sub-voxel vessel one voxel wide
+instead of dotted. It is not a dilation: every voxel the chain sets lies within
 `sqrt(3)/2` of the centreline, so for a radius of 0.866 voxels or more it is
 already inside the capsule and calibre is untouched. `--no-connect` restores the
 bare capsule rasterisation.
 
-Two things still legitimately split a rendered network into pieces, and neither
-is a defect:
+The chain is **face-connected** (6-connected), not merely 26-connected. The
+distinction matters downstream: a chain of voxels touching only at edges or
+corners is one piece to a 26-connected label but shatters under the
+six-connected flood fill, label or morphological operation most tools default
+to — `scipy.ndimage.label` among them — and looks like a string of beads in a
+viewer. Face connectivity is the weakest assumption any of them makes, so it is
+the one the rasteriser guarantees.
+
+Two ways of looking can still suggest breaks that are not there. A thin vessel
+running obliquely through a stack shows up in any single slice as isolated
+voxels even though it is unbroken in three dimensions, so judge connectivity
+with a 3-D component count rather than slice by slice. And a rendered network
+does still fall into several genuine pieces under two conditions, neither of
+them a defect:
 
 - **Clipping.** A branch that leaves a slab and re-enters it is two vessels in
-  the image, exactly as it would be in a real acquisition. `--clip-axes` and the
-  volume shape control this; with `--clip-axes none` a fitted network renders as
-  a single connected component.
+  the image, exactly as it would be in a real acquisition. The default volume
+  is such a slab — fitted in x and y, clipped in z — so this is what the
+  quickstart command produces: its deepest network, at twelve generations,
+  renders as 48 pieces, every one of them touching the top or bottom face of
+  the slab, with 95% of the vessel voxels in the largest. `--clip-axes` and
+  the volume shape control this. With `--clip-axes none` each of the five
+  quickstart networks renders as a single connected component, at the cost of
+  scaling the whole tree into 140 slices and so shrinking every vessel.
 - **Resolution.** A vessel the modality cannot resolve is still drawn, one voxel
   wide. To stop generating them instead, set `--d-min` to the smallest
   resolvable calibre.
@@ -278,8 +300,10 @@ command-line entry point. It also pins the centreline contract: a saved
 centreline re-renders the volume it was generated with, calibre in voxels
 scales as `1 / voxel_size`, and a sidecar plus its `.npz` reproduce the written
 TIFF exactly. Connectivity is covered too: an unclipped network renders as one
-26-connected component, bare capsules do not, and connecting changes nothing
-once a vessel fills a voxel.
+component under both 6- and 26-connectivity, the chain drawn for a segment is
+face-connected at every orientation and never strays more than `sqrt(3)/2`
+from it, bare capsules do break, and connecting changes nothing once a vessel
+fills a voxel.
 
 ---
 
@@ -307,9 +331,10 @@ Please cite the following if you use V-System in your research:
 Version 3.0 changes the interpreter, the grammars and the voxeliser as described
 above; volumes generated with it are not identical to those of earlier versions.
 Version 3.1 adds the centreline archive, the declared unit convention and the
-`d_min` stopping criterion. It also renders sub-voxel vessels as connected
+`d_min` stopping criterion. It also renders sub-voxel vessels as face-connected
 one-voxel paths rather than dotted lines, so its volumes contain vessels that
-3.0 dropped; `--no-connect` reproduces the 3.0 rasterisation.
+3.0 dropped and hold together under a six-connected label; `--no-connect`
+reproduces the 3.0 rasterisation.
 
 ---
 

--- a/analyseGrammar.py
+++ b/analyseGrammar.py
@@ -16,6 +16,15 @@ perpendicular vector and a diameter:
     [ ]      push and pop the whole state
     { }      delimit a segment whose points are interpolated as one curve
 
+A '[' met while a segment is open closes it, and the matching ']' opens a
+fresh one for the continuation. The stem is thereby pinned at the branch
+point: the part before it is one curve ending exactly there, the daughter
+starts exactly there, and the rest of the stem is a second curve starting
+exactly there. Had the daughter's points been folded into the parent's
+segment instead, the interpolating spline would have run past the branch
+point without touching it and the continuation would have restarted from a
+point the curve never visits, leaving the centreline disconnected.
+
 Upper-case letters are non-terminals left over from the recursion and draw
 nothing. Whitespace between tokens is ignored.
 """
@@ -100,7 +109,9 @@ def branching_turtle_to_coords(turtle_program, d0,
         tuple: (x, y, z, diameter, segment). `segment` is the index of the
         enclosing {...} segment, or -1 outside braces. The initial position
         is yielded first. A row of NaN marks the end of a branch (a ']'),
-        after which the restored point is yielded again.
+        after which the restored point is yielded again -- with a fresh
+        segment index if the branch was opened inside a segment, so that the
+        continuation is interpolated as its own curve from the branch point.
 
     Raises:
         ValueError: on a malformed program or unbalanced brackets.
@@ -138,10 +149,16 @@ def branching_turtle_to_coords(turtle_program, d0,
 
         elif command == "[":
             stack.append((pos, heading, perp, diam, segment))
+            segment = -1  # a branch leaving an open stem pins the stem here
         elif command == "]":
             if not stack:
                 raise ValueError("']' without a matching '['")
-            pos, heading, perp, diam, segment = stack.pop()
+            pos, heading, perp, diam, opened_in = stack.pop()
+            if opened_in >= 0:
+                segment = next_segment  # the rest of the stem is its own curve from here
+                next_segment += 1
+            else:
+                segment = -1
             yield _NAN_ROW
             yield (pos[0], pos[1], pos[2], diam, segment)
 

--- a/computeVoxel.py
+++ b/computeVoxel.py
@@ -24,11 +24,14 @@ slab would clip it.
 A capsule sets only the voxels whose centres it contains, so a vessel thinner
 than a voxel contains no centre along much of its length and rasterises as a
 dotted line, breaking a connected tree into fragments. Every segment is
-therefore also drawn as a 26-connected digital line, which renders a sub-voxel
-vessel one voxel wide instead of dotted and leaves everything else untouched: a
-voxel on the line lies within sqrt(3)/2 of the centreline, so for a radius of
-0.866 voxels or more the line is already inside the capsule. Pass
-connect=False for the bare capsule rasterisation.
+therefore also drawn as the face-connected chain of voxels it passes through,
+which renders a sub-voxel vessel one voxel wide instead of dotted and leaves
+everything else untouched: a voxel on the chain lies within sqrt(3)/2 of the
+centreline, so for a radius of 0.866 voxels or more the chain is already
+inside the capsule. Face connectivity matters because it is the weakest
+connectivity a downstream tool assumes -- a six-connected label or flood fill
+splits a chain that touches only at edges or corners. Pass connect=False for
+the bare capsule rasterisation.
 
 Coordinates and diameters arrive in grammar units. The pipeline treats one
 grammar unit as one micrometre, so `voxel_size` is a physical voxel size in
@@ -187,23 +190,43 @@ def rasterise_capsule(volume, p0, p1, r0, r1):
 
 def rasterise_line(volume, p0, p1):
     """
-    Sets a 26-connected chain of voxels along the segment from p0 to p1, so
-    that a vessel too thin to contain a voxel centre still renders as an
-    unbroken one-voxel path. Coordinates are voxel indices; voxels outside the
-    volume are dropped.
+    Sets every voxel the segment from p0 to p1 passes through, so that a
+    vessel too thin to contain a voxel centre still renders as an unbroken
+    face-connected path. Coordinates are voxel indices, voxel i spanning
+    [i - 0.5, i + 0.5); voxels outside the volume are dropped.
 
-    The segment is sampled finely enough that consecutive samples round to
-    voxels differing by at most one along each axis, which is what makes the
-    chain 26-connected. Every voxel it sets lies within sqrt(3)/2 of the
-    centreline, so for a radius of 0.866 voxels or more the capsule already
-    contains them and this adds nothing.
+    This is the voxel traversal of Amanatides and Woo (1987): from the voxel
+    containing p0 the walk steps across whichever face the segment crosses
+    next, one axis at a time, until it reaches the voxel containing p1.
+    Consecutive voxels therefore share a face, which is what a six-connected
+    flood fill, label or morphological operation needs; a chain touching only
+    at edges or corners falls apart under them. Every voxel visited is one the
+    segment passes through, so its centre lies within sqrt(3)/2 of the
+    centreline and the capsule already contains it once the radius reaches
+    0.866 voxels.
     """
     p0 = np.asarray(p0, dtype=float)
     p1 = np.asarray(p1, dtype=float)
     shape = np.asarray(volume.shape)
-    steps = max(int(np.ceil(np.max(np.abs(p1 - p0)) * 2.0)) + 1, 2)
-    t = np.linspace(0.0, 1.0, steps)
-    line = np.rint(p0[:, None] + t * (p1 - p0)[:, None]).astype(int)
+    direction = p1 - p0
+    cur = np.floor(p0 + 0.5).astype(int)
+    end = np.floor(p1 + 0.5).astype(int)
+    step = np.sign(direction).astype(int)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        # parameter at which the segment next crosses a face on each axis,
+        # and the parameter distance between successive crossings
+        t_next = np.where(direction != 0.0, (cur + 0.5 * step - p0) / direction, np.inf)
+        t_step = np.where(direction != 0.0, np.abs(1.0 / direction), np.inf)
+    visited = [cur.copy()]
+    # exactly one face crossing per unit of L1 distance between the end voxels;
+    # confining the choice to axes still short of the end makes the walk land
+    # on the end voxel whatever rounding does to a crossing at the boundary
+    for _ in range(int(np.abs(end - cur).sum())):
+        axis = int(np.argmin(np.where(cur != end, t_next, np.inf)))
+        cur[axis] += step[axis]
+        t_next[axis] += t_step[axis]
+        visited.append(cur.copy())
+    line = np.array(visited).T
     inside = np.all((line >= 0) & (line < shape[:, None]), axis=0)
     if not np.any(inside):
         return
@@ -220,11 +243,12 @@ def rasterise_segments(points, radii, tVol, connect=True):
         points (ndarray): (3, N) array of voxel coordinates, NaN separated.
         radii (ndarray): (N,) radii in voxels.
         tVol (sequence): volume shape (nx, ny, nz).
-        connect (bool): also draw each segment as a 26-connected digital line,
-            so that a vessel thinner than a voxel renders one voxel wide rather
-            than as a dotted line and the rendered tree stays as connected as
-            the geometry is. False gives the bare capsule rasterisation, which
-            drops sub-voxel vessels in and out along their length.
+        connect (bool): also draw each segment as the face-connected chain of
+            voxels it passes through, so that a vessel thinner than a voxel
+            renders one voxel wide rather than as a dotted line and the
+            rendered tree is as connected as the geometry, under six- as well
+            as 26-connectivity. False gives the bare capsule rasterisation,
+            which drops sub-voxel vessels in and out along their length.
 
     Returns:
         ndarray: uint8 volume of shape tVol with 1 inside vessels.

--- a/tests/test_vsystem.py
+++ b/tests/test_vsystem.py
@@ -169,6 +169,20 @@ class TurtleTests(unittest.TestCase):
         rows = list(branching_turtle_to_coords("{f(1,1)f(1,1)}f(1,1){f(1,1)}", 1.0))
         self.assertEqual([r[4] for r in rows], [-1, 0, 0, 0, -1, 1, 1])
 
+    def test_a_branch_inside_a_stem_pins_the_stem_at_the_branch_point(self):
+        # '[' closes the open segment and its ']' opens a fresh one, so the stem
+        # is two curves meeting exactly at the branch point rather than one curve
+        # that the interpolating spline would carry past it
+        rows = list(branching_turtle_to_coords("{f(1,1)[+(90)f(1,1)]f(1,1)}", 1.0))
+        segments = [r[4] for r in rows]
+        self.assertEqual(segments[:4], [-1, 0, 0, -1])       # start, '{', f, daughter f outside any segment
+        self.assertTrue(math.isnan(segments[4]))              # ']'
+        self.assertEqual(segments[5:], [1, 1])               # restored point and f in a fresh segment
+        self.assertEqual(rows[5][:3], rows[2][:3])            # ... starting exactly at the branch point
+        # a branch opened outside any segment leaves the indices as they were
+        rows = list(branching_turtle_to_coords("{f(1,1)}[+(90)f(1,1)]{f(1,1)}", 1.0))
+        self.assertEqual([r[4] for r in rows if not math.isnan(r[4])], [-1, 0, 0, -1, -1, 1, 1])
+
 
 class InterpolationTests(unittest.TestCase):
     def test_bspline_starts_and_ends_on_the_control_points(self):
@@ -561,6 +575,26 @@ class ConnectivityTests(unittest.TestCase):
                     total, reached = connected_count(volume, connectivity)
                     self.assertGreater(total, 0)
                     self.assertEqual(total, reached, f"{connectivity}-connectivity")
+
+    def test_a_branch_inside_a_stem_renders_connected(self):
+        # the interpolated continuation starts exactly where the first part of
+        # the stem ends, so the centreline -- and hence the volume -- is one piece
+        tVol = (64, 64, 64)
+        for program in ("{f(1,1)[+(90)f(1,1)]f(1,1)}",
+                        "{f(1,1)f(1,1)[+(90){f(1,1)f(1,1)}]f(1,1)f(1,1)}",
+                        "{f(1,1)[+(90)f(1,1)}]f(1,1)f(1,1)}"):
+            with self.subTest(program=program):
+                nodes = interpolate_segments(list(branching_turtle_to_coords(program, 1.0)))
+                separators = np.flatnonzero(np.isnan(nodes[0]))
+                for i in separators:  # each continuation restarts on a point the curve visited
+                    before = nodes[:3, :i]
+                    restart = nodes[:3, i + 1]
+                    self.assertTrue(np.any(np.all(np.isclose(before, restart[:, None]), axis=0)))
+                points, radii = fit_to_volume(nodes, tVol, clip_axes=())
+                volume = rasterise_segments(points, radii * 0.02, tVol)   # sub-voxel everywhere
+                total, reached = connected_count(volume, 6)
+                self.assertGreater(total, 0)
+                self.assertEqual(total, reached)
 
     def test_bare_capsules_break_the_same_network_apart(self):
         seed_all(3)

--- a/tests/test_vsystem.py
+++ b/tests/test_vsystem.py
@@ -52,10 +52,12 @@ def final_row(program, d0=5.0):
     return row
 
 
-def connected_count(volume):
+def connected_count(volume, connectivity=26):
     """
-    Returns (voxels set, voxels reachable from one of them under 26-connectivity),
-    so that the two are equal exactly when the rendered network is one piece.
+    Returns (voxels set, voxels reachable from one of them), so that the two
+    are equal exactly when the rendered network is one piece. Connectivity 26
+    joins voxels sharing a face, edge or corner; 6 joins only those sharing a
+    face, which is the weaker guarantee a downstream label or flood fill needs.
     """
     set_voxels = np.argwhere(volume)
     if len(set_voxels) == 0:
@@ -63,7 +65,8 @@ def connected_count(volume):
     shape = volume.shape
     neighbourhood = [(dx, dy, dz)
                      for dx in (-1, 0, 1) for dy in (-1, 0, 1) for dz in (-1, 0, 1)
-                     if (dx, dy, dz) != (0, 0, 0)]
+                     if (dx, dy, dz) != (0, 0, 0)
+                     and (connectivity == 26 or abs(dx) + abs(dy) + abs(dz) == 1)]
     seen = np.zeros(shape, dtype=bool)
     start = tuple(int(v) for v in set_voxels[0])
     seen[start] = True
@@ -487,25 +490,52 @@ class ConnectivityTests(unittest.TestCase):
     """
     A capsule sets only the voxels whose centres it contains, so a vessel
     thinner than a voxel would rasterise as a dotted line and break the tree
-    into fragments. Each segment is therefore also drawn as a connected digital
-    line.
+    into fragments. Each segment is therefore also drawn as the face-connected
+    chain of voxels it passes through -- face-connected, because a chain that
+    touches only at edges or corners is one piece under 26-connectivity yet
+    falls apart under the six-connected label or flood fill a downstream tool
+    is likely to apply.
     """
 
     def setUp(self):
         setProperties(PROPERTIES)
 
-    def test_a_sub_voxel_vessel_renders_as_one_unbroken_path(self):
+    def test_a_sub_voxel_vessel_renders_as_one_face_connected_path(self):
         points = np.array([[10.0, 60.0], [10.0, 55.0], [10.0, 52.0]])  # oblique, so it misses centres
         radii = np.array([0.2, 0.2])
         tVol = (72, 72, 72)
         dotted = rasterise_segments(points, radii, tVol, connect=False)
         joined = rasterise_segments(points, radii, tVol, connect=True)
         self.assertGreater(int(joined.sum()), int(dotted.sum()))
-        total, reached = connected_count(joined)
-        self.assertEqual(total, reached)
-        self.assertGreater(total, 50)
+        for connectivity in (26, 6):
+            with self.subTest(connectivity=connectivity):
+                total, reached = connected_count(joined, connectivity)
+                self.assertEqual(total, reached)
+                self.assertGreater(total, 50)
         dotted_total, dotted_reached = connected_count(dotted)
         self.assertLess(dotted_reached, dotted_total)  # the bare capsules really are broken
+
+    def test_the_line_is_face_connected_and_hugs_the_segment_at_every_orientation(self):
+        # every voxel visited is one the segment passes through, so consecutive
+        # voxels share a face and each centre lies within sqrt(3)/2 of the
+        # segment -- the bound that makes connecting a no-op for wider vessels
+        rng = np.random.default_rng(1)
+        for _ in range(60):
+            p0 = rng.uniform(30.0, 60.0, 3)
+            p1 = p0 + rng.uniform(-25.0, 25.0, 3)   # both ends stay inside the volume
+            volume = np.zeros((96, 96, 96), dtype=np.uint8)
+            rasterise_line(volume, p0, p1)
+            total, reached = connected_count(volume, 6)
+            self.assertEqual(total, reached)
+            self.assertGreater(total, 0)
+            voxels = np.argwhere(volume).astype(float)
+            axis = p1 - p0
+            t = np.clip(((voxels - p0) @ axis) / (axis @ axis), 0.0, 1.0)
+            distance = np.linalg.norm(voxels - (p0 + t[:, None] * axis), axis=1)
+            self.assertLessEqual(float(distance.max()), math.sqrt(3) / 2 + 1e-9)
+            # and the walk lands on the voxels containing the two ends
+            for end in (p0, p1):
+                self.assertEqual(volume[tuple(np.floor(end + 0.5).astype(int))], 1)
 
     def test_connecting_changes_nothing_once_a_vessel_fills_a_voxel(self):
         # every voxel the line sets is within sqrt(3)/2 of the centreline, so at
@@ -527,9 +557,10 @@ class ConnectivityTests(unittest.TestCase):
             with self.subTest(seed=seed):
                 seed_all(seed)
                 volume, _, _ = generate_network(niter, 20.0, PROPERTIES, tVol, clip_axes=())
-                total, reached = connected_count(volume)
-                self.assertGreater(total, 0)
-                self.assertEqual(total, reached)
+                for connectivity in (26, 6):
+                    total, reached = connected_count(volume, connectivity)
+                    self.assertGreater(total, 0)
+                    self.assertEqual(total, reached, f"{connectivity}-connectivity")
 
     def test_bare_capsules_break_the_same_network_apart(self):
         seed_all(3)


### PR DESCRIPTION
Follows #367, whose connectivity fix was incomplete: the line it drew along each thin segment was 26-connected, so consecutive voxels could touch only at an edge or a corner. That is one piece to a 26-connected label but falls apart under the six-connected flood fill, label or morphological operation most tools default to — `scipy.ndimage.label` among them — and reads as a string of beads in a viewer.

## What was wrong

For the README's quickstart command, `python main.py --count 5 --out ./output --seed 1`, counted with `scipy.ndimage.label` (6-connectivity):

| network | #367 | this change | `--clip-axes none` | residual pieces touching a z face |
| --- | --- | --- | --- | --- |
| `Lnet_i5_s1` | 2 | 2 | 1 | 1 / 1 |
| `Lnet_i4_s2` | 1 | 1 | 1 | — |
| `Lnet_i9_s3` | 20 | 5 | 1 | 4 / 4 |
| `Lnet_i10_s4` | 82 | 16 | 1 | 15 / 15 |
| `Lnet_i12_s5` | **661** | 48 | 1 | 47 / 47 |

A single oblique sub-voxel vessel split into 44 pieces. What remains after this change is slab clipping alone: every one of the 67 residual pieces across the five networks touches the top or bottom face of the 140-slice slab, and with `--clip-axes none` each network is exactly one component.

## The fix

`rasterise_line` now walks the segment with the voxel traversal of Amanatides & Woo (1987): from the voxel containing the start it steps across whichever face the segment crosses next, one axis at a time, until it reaches the voxel containing the end. Consecutive voxels therefore share a face. Every voxel visited is one the segment passes through, so its centre lies within `sqrt(3)/2` of the centreline and the capsule already contains it once the radius reaches 0.866 voxels — the no-op bound of #367 is unchanged, so calibre of resolvable vessels is untouched.

The walk takes exactly one step per unit of L1 distance between the end voxels, choosing only among axes still short of the end, so it terminates on the end voxel whatever floating-point rounding does to a crossing that lands on a boundary. Rendering is about ten percent slower.

## A second, latent break in the interpreter

A `[` met while a `{…}` segment was open left the segment open, so the daughter's points carried the parent's segment index and `interpolate_segments` splined parent and daughter together as one control polygon. A clamped B-spline passes through only its first and last control points, so the curve ran past the branch point without touching it, and the continuation re-yielded after `]` restarted from a point the curve never visited: the centreline itself was disconnected, and at sub-voxel radius the volume rendered as two pieces whatever the rasteriser did.

None of the shipped grammars opens a branch inside a stem, so their output is unchanged to the bit (`F`, `A`, `I` and `example` verified identical across five seeds against the previous interpreter); the interpreter accepted the construction silently from a hand-written program. A `[` now closes an open segment and its matching `]` opens a fresh one, so the stem is pinned at the branch point: the part before it is one curve ending exactly there, the daughter starts exactly there, and the rest of the stem is a second curve starting exactly there.

## Documentation

The README's Connectivity section now explains why face connectivity is the guarantee that matters, notes that a thin oblique vessel shows as isolated voxels in any single slice even when unbroken in three dimensions (so connectivity is judged by a 3-D component count), and quantifies what slab clipping leaves for the quickstart command and how to change it. The Usage section says up front that the default volume is a slab, and the Grammar section states the branch-inside-a-stem rule.

## Verification

68 tests, pyflakes clean. An unclipped network renders as one component under both 6- and 26-connectivity; the chain drawn for a segment is face-connected at every orientation, never strays more than `sqrt(3)/2` from the segment, and lands on the voxels containing both ends; a branch opened inside a stem yields the documented segment indices, every continuation restarts on a point the curve visited, and such programs render as one six-connected piece. Outside the suite, 2,300 segments were fuzzed against a dense brute-force supercover — endpoints on faces, edges and corners, exact diagonals, axis-parallel, sub-1e-9 and 40-voxel lengths, degenerate `p0 == p1`: 0 not face-connected, 0 voxels beyond the bound, 0 voxels the segment passes through that the walk skipped.