### PR TITLE
Add a connectivity check and an option to grow the tree inside the volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Useful options (`python main.py --help` lists them all):
 | `--fit` | `isotropic` | `isotropic`, `voxel_size` (fixed `--voxel-size`) or `stretch` (legacy per-axis fill) |
 | `--voxel-size` | none | grammar units per voxel for `--fit voxel_size`: the modality's voxel size |
 | `--clip-axes` | `z` | axes left out of the isotropic fit and clipped, as an imaging slab would |
+| `--grow-in-volume` | off | confine growth to the volume's proportions so no vessel is cut |
 | `--no-connect` | off | rasterise bare capsules, leaving sub-voxel vessels dotted |
 | `--units` | `um` | the unit one grammar unit stands for, recorded in the sidecar |
 
@@ -182,7 +183,17 @@ does still fall into several genuine pieces under two conditions, neither of
 them a defect:
 
 - **Clipping.** A branch that leaves a slab and re-enters it is two vessels in
-  the image, exactly as it would be in a real acquisition. The default volume
+  the image, exactly as it would be in a real acquisition. `--grow-in-volume`
+  removes this at the source: growth is confined to a box with the volume's
+  proportions and a branch that would leave it is terminated along with its
+  subtree, so the tree takes the volume's shape and no vessel is ever cut part
+  way along. On a `512 × 512 × 140` slab at twelve generations that turns 43
+  pieces into one while raising the vessel count, because branches that used to
+  grow out of the slab and be discarded now stay inside it. `--clip-axes` is
+  unused when it is set, and it is off by default so existing output is
+  unchanged. A volume with equal axes needs none of this: the grammar grows a
+  roughly cubical tree, so `--volume 512 512 512 --clip-axes none` is one
+  connected piece at the same calibre. The default volume
   is such a slab — fitted in x and y, clipped in z — so this is what the
   quickstart command produces: its deepest network, at twelve generations,
   renders as 48 pieces, every one of them touching the top or bottom face of

--- a/README.md
+++ b/README.md
@@ -159,6 +159,21 @@ to — `scipy.ndimage.label` among them — and looks like a string of beads in 
 viewer. Face connectivity is the weakest assumption any of them makes, so it is
 the one the rasteriser guarantees.
 
+`check_connectivity.py` answers the question for a given network. It reports the
+components of a volume under both 6- and 26-connectivity and, for every piece
+but the largest, whether that piece touches a face of the volume — a piece that
+does is a branch the volume cut, a piece that does not is a real break. It also
+checks a saved `.npz` centreline as pure geometry, independently of any volume,
+where anything but one component is a defect. `--generate N` makes fresh
+networks to check instead of reading files, passing every other option through
+to the generator, and the exit status is 1 only for a break the volume boundary
+does not explain:
+
+```bash
+python check_connectivity.py --generate 10 --seed 1
+python check_connectivity.py output/*.npz output/*.tiff
+```
+
 Two ways of looking can still suggest breaks that are not there. A thin vessel
 running obliquely through a stack shows up in any single slice as isolated
 voxels even though it is unbroken in three dimensions, so judge connectivity

--- a/analyseGrammar.py
+++ b/analyseGrammar.py
@@ -95,7 +95,8 @@ def _angle(params, default):
 def branching_turtle_to_coords(turtle_program, d0,
                                position=(0.0, 0.0, 0.0),
                                direction=(0.0, 1.0, 0.0),
-                               perpendicular=(0.0, 0.0, 1.0)):
+                               perpendicular=(0.0, 0.0, 1.0),
+                               bounds=None):
     """
     Interprets a turtle program and yields its points.
 
@@ -104,6 +105,12 @@ def branching_turtle_to_coords(turtle_program, d0,
         d0 (float): initial diameter.
         position, direction, perpendicular: initial state; direction and
             perpendicular must be orthogonal. The defaults are the source's.
+        bounds (sequence or None): ((x0, y0, z0), (x1, y1, z1)) in grammar
+            units. A move that would leave the box terminates its branch: the
+            move and everything descending from it are skipped, up to the ']'
+            that closes the branch. The tree therefore grows within the box and
+            no vessel is ever cut part way along, unlike a network rendered
+            larger than its volume and cropped. None grows without limit.
 
     Yields:
         tuple: (x, y, z, diameter, segment). `segment` is the index of the
@@ -114,7 +121,8 @@ def branching_turtle_to_coords(turtle_program, d0,
         continuation is interpolated as its own curve from the branch point.
 
     Raises:
-        ValueError: on a malformed program or unbalanced brackets.
+        ValueError: on a malformed program, unbalanced brackets, an empty box,
+            or a starting position outside it.
     """
     pos = np.asarray(position, dtype=float)
     heading = unit(direction)
@@ -125,17 +133,36 @@ def branching_turtle_to_coords(turtle_program, d0,
     if not diam > 0:
         raise ValueError(f"the initial diameter must be positive, got {d0!r}")
 
+    low = high = None
+    if bounds is not None:
+        low, high = (np.asarray(b, dtype=float) for b in bounds)
+        if low.shape != (3,) or high.shape != (3,) or np.any(high <= low):
+            raise ValueError("bounds must be ((x0, y0, z0), (x1, y1, z1)) with x1 > x0 and so on")
+        if np.any(pos < low) or np.any(pos > high):
+            raise ValueError(f"the starting position {tuple(pos)} is outside the bounds")
+
     stack = []
     segment = -1
     next_segment = 0
+    depth = 0
+    pruned_at = None      # the bracket depth of the branch a bound terminated, if any
     yield (pos[0], pos[1], pos[2], diam, segment)
 
     for command, params in tokenise(turtle_program):
+        # a terminated branch draws nothing until the ']' that closes it, but its
+        # brackets are still counted so that the matching one is recognised
+        if pruned_at is not None and command not in ("[", "]"):
+            continue
+
         if command in MOVE_COMMANDS:
             length = params[0] if params else getLength(diam)
             if len(params) > 1 and params[1] > 0.0:
                 diam = params[1]
-            pos = pos + length * heading
+            step = pos + length * heading
+            if low is not None and (np.any(step < low) or np.any(step > high)):
+                pruned_at = depth       # this branch leaves the box: drop it and its subtree
+                continue
+            pos = step
             yield (pos[0], pos[1], pos[2], diam, segment)
 
         elif command == "+":
@@ -148,9 +175,17 @@ def branching_turtle_to_coords(turtle_program, d0,
             perp = rotate_about(perp, heading, -_angle(params, lambda: lg.roll_angle))
 
         elif command == "[":
+            depth += 1
+            if pruned_at is not None:
+                continue
             stack.append((pos, heading, perp, diam, segment))
             segment = -1  # a branch leaving an open stem pins the stem here
         elif command == "]":
+            depth -= 1
+            if pruned_at is not None:
+                if depth >= pruned_at:
+                    continue            # still inside the terminated branch
+                pruned_at = None        # the branch ends here, so drawing resumes
             if not stack:
                 raise ValueError("']' without a matching '['")
             pos, heading, perp, diam, opened_in = stack.pop()

--- a/check_connectivity.py
+++ b/check_connectivity.py
@@ -267,19 +267,24 @@ def main(argv=None):
     args = parser.parse_args(argv)
 
     problems = 0
+    missing = 0
     for path in args.paths:
         if not os.path.exists(path):
             print(f"{path}: no such file", file=sys.stderr)
-            problems += 1
+            missing += 1                      # an unreadable path is not a connectivity result
             continue
         if path.endswith(".npz"):
             problems += check_centreline(path)
         else:
             problems += check_volume(path)
         print()
+    if missing:
+        print(f"{missing} path(s) could not be read")
     if problems:
         print(f"{problems} break(s) not explained by the volume boundary")
-    return 1 if problems else 0
+    if not missing and not problems:
+        print("no break beyond what the volume cut")
+    return 1 if (problems or missing) else 0
 
 
 if __name__ == "__main__":

--- a/check_connectivity.py
+++ b/check_connectivity.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""
+Reports whether a generated network is one connected piece, and when it is not,
+whether the volume's own boundary accounts for the breaks.
+
+    python check_connectivity.py --generate 10 --seed 1
+    python check_connectivity.py --generate 5 --volume 256 256 70 --iterations 8 8
+    python check_connectivity.py output/*.tiff
+    python check_connectivity.py output/*.npz output/*.tiff
+
+`--generate N` makes N fresh networks and checks them without writing any files.
+Every other option is passed through to the generator, so the networks are the
+ones `main.py` would write for the same seeds and settings.
+
+A centreline archive (.npz) is checked as geometry: the branches are walked and
+joined wherever they share a point, so the answer is independent of any volume.
+More than one component there is a defect in generation or interpretation.
+
+A volume (.tiff) is checked as voxels, under both six-connectivity (faces only,
+what a flood fill, `scipy.ndimage.label` or a morphological operation assumes by
+default) and 26-connectivity (faces, edges and corners). Every piece other than
+the largest is then tested against the six faces of the volume: a piece that
+touches one is a branch the volume cut, which is expected whenever the network
+is larger than the box it is rendered into. A piece touching no face is a break
+the boundary does not explain, and is the signature of a real defect.
+
+The exit status is 1 if any file has a break the boundary does not explain, so
+this can gate a pipeline; a network merely clipped by its volume exits 0.
+"""
+import argparse
+import itertools
+import os
+import sys
+
+import numpy as np
+
+AXES = "xyz"
+
+
+def label(mask, connectivity=6):
+    """
+    Labels the connected components of a boolean array by union-find.
+
+    Args:
+        mask (ndarray): 3-D boolean array.
+        connectivity (int): 6 joins voxels sharing a face, 26 also joins those
+            sharing only an edge or a corner.
+
+    Returns:
+        tuple: (sizes, labels) with sizes the voxel count of each component in
+        descending order and labels a 3-D array of 1-based component indices
+        matching that order, 0 outside the mask.
+    """
+    flat = np.flatnonzero(mask.ravel())
+    if flat.size == 0:
+        return np.zeros(0, dtype=np.int64), np.zeros(mask.shape, dtype=np.int64)
+
+    lookup = np.full(mask.size, -1, dtype=np.int64)
+    lookup[flat] = np.arange(flat.size)
+    parent = np.arange(flat.size, dtype=np.int64)
+
+    def find(a):
+        root = a
+        while parent[root] != root:
+            root = parent[root]
+        while parent[a] != root:          # path compression, so repeated finds stay cheap
+            parent[a], a = root, parent[a]
+        return root
+
+    coords = np.stack(np.unravel_index(flat, mask.shape), axis=1)
+    shape = np.array(mask.shape)
+    if connectivity == 6:
+        offsets = [(1, 0, 0), (0, 1, 0), (0, 0, 1)]
+    else:                                  # the forward half of the 26-neighbourhood
+        offsets = [o for o in itertools.product((-1, 0, 1), repeat=3) if o > (0, 0, 0)]
+
+    for offset in offsets:
+        moved = coords + offset
+        within = np.all((moved >= 0) & (moved < shape), axis=1)
+        if not within.any():
+            continue
+        neighbour = lookup[np.ravel_multi_index(moved[within].T, mask.shape)]
+        source = np.flatnonzero(within)
+        joined = neighbour >= 0
+        for a, b in zip(source[joined], neighbour[joined]):
+            ra, rb = find(int(a)), find(int(b))
+            if ra != rb:
+                parent[max(ra, rb)] = min(ra, rb)
+
+    roots = np.fromiter((find(i) for i in range(flat.size)), dtype=np.int64, count=flat.size)
+    _, index, counts = np.unique(roots, return_inverse=True, return_counts=True)
+    order = np.argsort(counts)[::-1]
+    rank = np.empty(order.size, dtype=np.int64)
+    rank[order] = np.arange(order.size)
+    labels = np.zeros(mask.size, dtype=np.int64)
+    labels[flat] = rank[index] + 1
+    return counts[order], labels.reshape(mask.shape)
+
+
+def report_volume(volume, name):
+    """
+    Reports the components of a rendered volume, indexed (x, y, z), and how many
+    of them the volume's own boundary explains. Returns the number it does not.
+    """
+    volume = np.asarray(volume) > 0
+    total = int(volume.sum())
+    if total == 0:
+        print(f"{name}: empty volume, no vessels")
+        return 0
+
+    sizes, labels = label(volume, 6)
+    sizes26, _ = label(volume, 26)
+    print(f"{name}: {volume.shape[0]}x{volume.shape[1]}x{volume.shape[2]}, "
+          f"{total} vessel voxels")
+    print(f"    components: {sizes.size} six-connected, {sizes26.size} 26-connected; "
+          f"largest holds {sizes[0] / total * 100:.1f}%")
+    if sizes.size == 1:
+        print("    one piece: connected")
+        return 0
+
+    unexplained = []
+    faces = np.zeros(3, dtype=int)
+    for k in range(2, sizes.size + 1):                 # every piece but the largest
+        where = np.argwhere(labels == k)
+        low = where.min(axis=0)
+        high = where.max(axis=0)
+        touching = [a for a in range(3)
+                    if low[a] == 0 or high[a] == volume.shape[a] - 1]
+        if touching:
+            for a in touching:
+                faces[a] += 1
+        else:
+            unexplained.append((k, int(sizes[k - 1]), low, high))
+
+    cut = sizes.size - 1 - len(unexplained)
+    print(f"    of the {sizes.size - 1} smaller pieces, {cut} touch a face of the volume "
+          f"(cut by it: " + ", ".join(f"{AXES[a]} {faces[a]}" for a in range(3)) + ")")
+    if unexplained:
+        print(f"    {len(unexplained)} piece(s) touch NO face -- the volume does not explain these:")
+        for k, size, low, high in unexplained[:10]:
+            print(f"        piece {k}: {size} voxels, x {low[0]}-{high[0]}, "
+                  f"y {low[1]}-{high[1]}, z {low[2]}-{high[2]}")
+        if len(unexplained) > 10:
+            print(f"        ... and {len(unexplained) - 10} more")
+    else:
+        print("    every break is the volume cutting the network, not a defect")
+    return len(unexplained)
+
+
+def check_volume(path):
+    """Reads a written TIFF and reports it. Returns the unexplained piece count."""
+    import tifffile
+    stack = tifffile.imread(path)
+    # pages are z, rows y and columns x; the generator indexes (x, y, z)
+    return report_volume(np.transpose(stack, (2, 1, 0)), os.path.basename(path))
+
+
+def report_centreline(nodes, name):
+    """
+    Reports whether a centreline is connected, independently of any volume.
+    Returns the number of components beyond the first.
+    """
+    finite = np.flatnonzero(~np.isnan(nodes[0]))
+    if finite.size == 0:
+        print(f"{name}: empty centreline")
+        return 0
+    gaps = np.flatnonzero(np.diff(finite) > 1)
+    starts = np.concatenate([[0], gaps + 1])
+    ends = np.concatenate([gaps + 1, [finite.size]])
+    chains = [finite[s:e] for s, e in zip(starts, ends)]
+
+    parent = list(range(len(chains)))
+
+    def find(a):
+        while parent[a] != a:
+            parent[a] = parent[parent[a]]
+            a = parent[a]
+        return a
+
+    owner = {}
+    for ci, chain in enumerate(chains):
+        for j in chain:
+            key = nodes[:3, j].tobytes()      # a branch starts exactly on a point of its parent
+            if key in owner:
+                ra, rb = find(ci), find(owner[key])
+                if ra != rb:
+                    parent[max(ra, rb)] = min(ra, rb)
+            else:
+                owner[key] = ci
+    components = len({find(i) for i in range(len(chains))})
+
+    diam = nodes[3][~np.isnan(nodes[3])]
+    print(f"{name}: {len(chains)} branches, {finite.size} points, "
+          f"diameters {diam.min():.3f}-{diam.max():.3f}")
+    print(f"    centreline components: {components}"
+          + ("  (connected)" if components == 1 else "  <-- the geometry itself is broken"))
+    return components - 1
+
+
+def check_centreline(path):
+    """Reads a saved centreline archive and reports it."""
+    from main import load_network
+    return report_centreline(load_network(path)["nodes"], os.path.basename(path))
+
+
+def generate_and_check(count, passthrough):
+    """
+    Generates `count` networks with the generator's own parser and settings and
+    reports each one. Nothing is written to disk. Returns the number of networks
+    carrying a break the volume boundary does not explain.
+    """
+    import random
+    from main import build_parser, generate_network, sample_parameters
+
+    args = build_parser().parse_args(passthrough)
+    if args.fit == "voxel_size" and args.voxel_size is None:
+        raise SystemExit("--fit voxel_size requires --voxel-size")
+    base = args.seed if args.seed is not None else random.SystemRandom().randrange(2 ** 31)
+    tVol = tuple(args.volume)
+    print(f"generating {count} network(s) at {tVol[0]}x{tVol[1]}x{tVol[2]}, "
+          f"fit {args.fit}, clip axes {[AXES[a] for a in args.clip_axes] or 'none'}, "
+          f"connect {args.connect}, seeds {base}..{base + count - 1}\n")
+
+    failed = 0
+    for index in range(count):
+        seed = base + index
+        random.seed(seed)                      # the seeding main() uses, so these are its networks
+        np.random.seed(seed % (2 ** 32))
+        properties, d0, niter = sample_parameters(args)
+        if args.d_min is not None and d0 < args.d_min:
+            print(f"seed {seed}: --d-min exceeds the sampled root diameter, skipped\n")
+            continue
+        volume, _, nodes = generate_network(niter, d0, properties, tVol, fit=args.fit,
+                                            clip_axes=args.clip_axes, voxel_size=args.voxel_size,
+                                            subdivisions=args.subdivisions, d_min=args.d_min,
+                                            connect=args.connect)
+        stem = f"Lnet_i{niter}_s{seed}"
+        broken = report_centreline(nodes, stem + " (centreline)")
+        broken += report_volume(volume, stem + " (volume)")
+        failed += 1 if broken else 0
+        print()
+    print(f"{count - failed}/{count} network(s) had no break beyond what the volume cut")
+    return failed
+
+
+def main(argv=None):
+    argv = list(sys.argv[1:] if argv is None else argv)
+    # --generate forwards everything else to the generator's own parser, so peel it
+    # off first: a positional list here would swallow operands like "--volume 256 256 70"
+    peel = argparse.ArgumentParser(add_help=False)
+    peel.add_argument("--generate", type=int, metavar="N")
+    peeled, passthrough = peel.parse_known_args(argv)
+    if peeled.generate is not None:
+        if peeled.generate < 1:
+            raise SystemExit("--generate needs a positive count")
+        return 1 if generate_and_check(peeled.generate, passthrough) else 0
+
+    parser = argparse.ArgumentParser(
+        description="Report the connectivity of generated networks and whether the "
+                    "volume boundary explains any breaks.",
+        epilog="With --generate, every other option is passed to the generator, so "
+               "'--generate 5 --seed 1 --iterations 8 8' checks the networks "
+               "'main.py --count 5 --seed 1 --iterations 8 8' would write.")
+    parser.add_argument("paths", nargs="+", help=".tiff volumes and/or .npz centrelines")
+    parser.add_argument("--generate", type=int, metavar="N",
+                        help="generate and check N fresh networks instead of reading files")
+    args = parser.parse_args(argv)
+
+    problems = 0
+    for path in args.paths:
+        if not os.path.exists(path):
+            print(f"{path}: no such file", file=sys.stderr)
+            problems += 1
+            continue
+        if path.endswith(".npz"):
+            problems += check_centreline(path)
+        else:
+            problems += check_volume(path)
+        print()
+    if problems:
+        print(f"{problems} break(s) not explained by the volume boundary")
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/check_connectivity.py
+++ b/check_connectivity.py
@@ -217,8 +217,10 @@ def generate_and_check(count, passthrough):
         raise SystemExit("--fit voxel_size requires --voxel-size")
     base = args.seed if args.seed is not None else random.SystemRandom().randrange(2 ** 31)
     tVol = tuple(args.volume)
+    shaping = ("grown in the volume" if args.grow_in_volume
+               else f"clip axes {[AXES[a] for a in args.clip_axes] or 'none'}")
     print(f"generating {count} network(s) at {tVol[0]}x{tVol[1]}x{tVol[2]}, "
-          f"fit {args.fit}, clip axes {[AXES[a] for a in args.clip_axes] or 'none'}, "
+          f"fit {args.fit}, {shaping}, "
           f"connect {args.connect}, seeds {base}..{base + count - 1}\n")
 
     failed = 0
@@ -233,7 +235,8 @@ def generate_and_check(count, passthrough):
         volume, _, nodes = generate_network(niter, d0, properties, tVol, fit=args.fit,
                                             clip_axes=args.clip_axes, voxel_size=args.voxel_size,
                                             subdivisions=args.subdivisions, d_min=args.d_min,
-                                            connect=args.connect)
+                                            connect=args.connect,
+                                            grow_in_volume=args.grow_in_volume)
         stem = f"Lnet_i{niter}_s{seed}"
         broken = report_centreline(nodes, stem + " (centreline)")
         broken += report_volume(volume, stem + " (volume)")

--- a/main.py
+++ b/main.py
@@ -29,6 +29,7 @@ convention it was written under in its "units" field.
 """
 import argparse
 import json
+import math
 import os
 import random
 import sys
@@ -52,7 +53,7 @@ DEFAULT_UNITS = "um"
 def generate_network(niter, d0, properties, tVol, fit="isotropic", clip_axes=(2,),
                      voxel_size=None, subdivisions=3,
                      direction=(0.0, 1.0, 0.0), perpendicular=(0.0, 0.0, 1.0),
-                     d_min=None, connect=True):
+                     d_min=None, connect=True, grow_in_volume=False):
     """
     Generates one network and renders it into a volume.
 
@@ -76,6 +77,12 @@ def generate_network(niter, d0, properties, tVol, fit="isotropic", clip_axes=(2,
         connect (bool): see computeVoxel.rasterise_segments. Left true, a vessel
             too thin to contain a voxel centre still renders as an unbroken
             one-voxel path instead of a dotted line.
+        grow_in_volume (bool): confine growth to a box with the volume's
+            proportions, terminating any branch that would leave it, so the tree
+            takes the volume's shape and no vessel is cut part way along. The
+            box is `tVol` times `voxel_size` under the voxel_size fit, and
+            otherwise the largest box of those proportions the tree still
+            overflows. `clip_axes` is then ignored, since nothing is clipped.
 
     Returns:
         tuple: (volume, program, nodes) with volume a uint8 array of 0 and 1,
@@ -88,7 +95,31 @@ def generate_network(niter, d0, properties, tVol, fit="isotropic", clip_axes=(2,
     """
     libGenerator.setProperties(properties)
     program = F(niter, d0, d_min)
-    rows = branching_turtle_to_coords(program, d0, direction=direction, perpendicular=perpendicular)
+    bounds = None
+    position = (0.0, 0.0, 0.0)
+    if grow_in_volume:
+        shape = np.asarray(tVol, dtype=float)
+        if fit == "voxel_size":
+            if voxel_size is None or voxel_size <= 0:
+                raise ValueError("growing in the volume at a fixed voxel size needs a positive "
+                                 "voxel_size, since it sets the field of view in grammar units")
+            box = shape * float(voxel_size)
+        else:
+            # Interpreting the grammar consumes no randomness -- every token F emits
+            # carries its operands -- so measuring the free extent first is safe. The
+            # box takes the volume's proportions at the largest size the tree still
+            # overflows, so growth is confined rather than merely contained.
+            free = np.array([row[:3] for row in
+                             branching_turtle_to_coords(program, d0, direction=direction,
+                                                        perpendicular=perpendicular)
+                             if not math.isnan(row[0])])
+            extent = free.max(axis=0) - free.min(axis=0)
+            box = shape * float(np.min(extent / shape))
+        bounds = (np.zeros(3), box)
+        position = (box[0] / 2.0, 0.0, box[2] / 2.0)
+        clip_axes = ()          # the tree already fits, so clipping has nothing to do
+    rows = branching_turtle_to_coords(program, d0, position=position, direction=direction,
+                                      perpendicular=perpendicular, bounds=bounds)
     nodes = interpolate_segments(rows, subdivisions=subdivisions)
     volume = process_network(nodes, tVol, fit=fit, voxel_size=voxel_size, clip_axes=clip_axes,
                              connect=connect)
@@ -243,6 +274,9 @@ def build_parser():
                         help="physical unit one grammar unit stands for, recorded in the sidecar "
                              f"(default {DEFAULT_UNITS}); it labels --d0, --d-min and --voxel-size "
                              "and does not rescale anything")
+    parser.add_argument("--grow-in-volume", action="store_true",
+                        help="confine growth to the volume's proportions so the tree takes its "
+                             "shape and no vessel is cut part way along; --clip-axes is then unused")
     parser.add_argument("--no-connect", action="store_false", dest="connect",
                         help="rasterise bare capsules, so that a vessel thinner than a voxel "
                              "renders as a dotted line rather than a one-voxel path")
@@ -273,7 +307,8 @@ def main(argv=None):
         volume, program, nodes = generate_network(niter, d0, properties, tVol, fit=args.fit,
                                                   clip_axes=args.clip_axes, voxel_size=args.voxel_size,
                                                   subdivisions=args.subdivisions, d_min=args.d_min,
-                                                  connect=args.connect)
+                                                  connect=args.connect,
+                                                  grow_in_volume=args.grow_in_volume)
         stem = f"Lnet_i{niter}_s{seed}"
         write_volume(os.path.join(args.out, stem + ".tiff"), volume)
         record = {
@@ -286,8 +321,9 @@ def main(argv=None):
             "axis_order": "zyx",
             "units": args.units,
             "fit": args.fit,
-            "clip_axes": list(args.clip_axes),
+            "clip_axes": [] if args.grow_in_volume else list(args.clip_axes),
             "connect": args.connect,
+            "grow_in_volume": args.grow_in_volume,
             "voxel_size": args.voxel_size,
             "subdivisions": args.subdivisions,
         }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,4 +27,4 @@ vsystem = "main:main"
 Repository = "https://github.com/psweens/V-System"
 
 [tool.setuptools]
-py-modules = ["main", "vSystem", "libGenerator", "analyseGrammar", "utils", "computeVoxel", "preprocessing", "visuals"]
+py-modules = ["main", "vSystem", "libGenerator", "analyseGrammar", "utils", "computeVoxel", "preprocessing", "visuals", "check_connectivity"]

--- a/tests/test_vsystem.py
+++ b/tests/test_vsystem.py
@@ -6,7 +6,9 @@ Run from the repository root with either
 or
     python -m pytest
 """
+import contextlib
 import importlib
+import io
 import math
 import os
 import random
@@ -27,7 +29,9 @@ from analyseGrammar import branching_turtle_to_coords, tokenise  # noqa: E402
 from utils import interpolate_segments, bspline, rotate_about  # noqa: E402
 from computeVoxel import (process_network, rasterise_segments, fit_to_volume,  # noqa: E402
                           normalise_axes, rasterise_line)
-from main import generate_network, load_network, save_network  # noqa: E402
+from main import generate_network, load_network, save_network, write_volume  # noqa: E402
+from check_connectivity import (label, check_volume, check_centreline,  # noqa: E402
+                                generate_and_check)
 
 PROPERTIES = {"k": 3, "epsilon": 7.0, "randmarg": 0.2, "sigma": 5, "stochparams": True}
 
@@ -91,7 +95,7 @@ def angle_between(a, b):
 class ImportTests(unittest.TestCase):
     def test_every_module_imports_on_the_installed_stack(self):
         for name in ("libGenerator", "vSystem", "analyseGrammar", "utils",
-                     "computeVoxel", "preprocessing", "visuals"):
+                     "computeVoxel", "preprocessing", "visuals", "check_connectivity"):
             with self.subTest(module=name):
                 importlib.import_module(name)
 
@@ -621,6 +625,107 @@ class ConnectivityTests(unittest.TestCase):
         total, reached = connected_count(volume)
         self.assertGreater(total, 0)
         self.assertLess(reached, total)
+
+
+class ConnectivityReportTests(unittest.TestCase):
+    """
+    check_connectivity separates a network the volume merely cut from one that
+    is genuinely broken, so a clipped slab does not read as a defect.
+    """
+
+    def setUp(self):
+        setProperties(PROPERTIES)
+
+    def _report(self, volume):
+        with tempfile.TemporaryDirectory() as out:
+            path = os.path.join(out, "v.tiff")
+            write_volume(path, volume)
+            with contextlib.redirect_stdout(io.StringIO()) as captured:
+                unexplained = check_volume(path)
+        return unexplained, captured.getvalue()
+
+    def test_components_are_counted_and_ordered_by_size(self):
+        volume = np.zeros((10, 10, 10), dtype=np.uint8)
+        volume[1:3, 1:3, 1:3] = 1                      # 8 voxels
+        volume[6:9, 6:9, 6:9] = 1                      # 27 voxels
+        sizes, labels = label(volume, 6)
+        self.assertEqual(list(sizes), [27, 8])         # largest first
+        self.assertEqual(labels[7, 7, 7], 1)
+        self.assertEqual(labels[1, 1, 1], 2)
+        self.assertEqual(int((labels > 0).sum()), 35)
+
+    def test_a_corner_touching_chain_splits_under_six_connectivity(self):
+        volume = np.zeros((8, 8, 8), dtype=np.uint8)
+        for i in range(5):
+            volume[i, i, i] = 1                        # touches only at corners
+        self.assertEqual(label(volume, 26)[0].size, 1)
+        self.assertEqual(label(volume, 6)[0].size, 5)
+
+    def test_an_empty_volume_has_no_components(self):
+        sizes, labels = label(np.zeros((4, 4, 4), dtype=np.uint8), 6)
+        self.assertEqual(sizes.size, 0)
+        self.assertEqual(int(labels.sum()), 0)
+
+    def test_a_piece_on_a_face_is_the_volume_cutting_and_one_inside_is_not(self):
+        body = np.zeros((20, 20, 20), dtype=np.uint8)
+        body[5:15, 5:15, 5:15] = 1
+
+        unexplained, text = self._report(body)
+        self.assertEqual(unexplained, 0)
+        self.assertIn("one piece: connected", text)
+
+        cut = body.copy()
+        cut[2, 2, 0] = 1                               # isolated, but on the z face
+        unexplained, text = self._report(cut)
+        self.assertEqual(unexplained, 0)
+        self.assertIn("not a defect", text)
+
+        broken = body.copy()
+        broken[2, 2, 2] = 1                            # isolated and touching no face
+        unexplained, text = self._report(broken)
+        self.assertEqual(unexplained, 1)
+        self.assertIn("touch NO face", text)
+
+    def test_bare_capsules_are_reported_as_breaks_the_volume_cannot_explain(self):
+        seed_all(3)
+        volume, _, _ = generate_network(7, 20.0, PROPERTIES, (96, 96, 96),
+                                        clip_axes=(), connect=False)
+        unexplained, _ = self._report(volume)
+        self.assertGreater(unexplained, 0)
+        seed_all(3)
+        volume, _, _ = generate_network(7, 20.0, PROPERTIES, (96, 96, 96),
+                                        clip_axes=(), connect=True)
+        unexplained, text = self._report(volume)
+        self.assertEqual(unexplained, 0)
+        self.assertIn("one piece: connected", text)
+
+    def test_generating_fresh_networks_reports_each_one(self):
+        with contextlib.redirect_stdout(io.StringIO()) as captured:
+            failed = generate_and_check(2, ["--seed", "1", "--volume", "64", "64", "64",
+                                            "--iterations", "5", "5", "--clip-axes", "none"])
+        text = captured.getvalue()
+        self.assertEqual(failed, 0)
+        self.assertIn("Lnet_i5_s1", text)
+        self.assertIn("Lnet_i5_s2", text)
+        self.assertIn("2/2", text)
+
+    def test_generating_with_bare_capsules_is_reported_as_broken(self):
+        with contextlib.redirect_stdout(io.StringIO()) as captured:
+            failed = generate_and_check(1, ["--seed", "1", "--volume", "64", "64", "64",
+                                            "--iterations", "7", "7", "--clip-axes", "none",
+                                            "--no-connect"])
+        self.assertEqual(failed, 1)
+        self.assertIn("touch NO face", captured.getvalue())
+
+    def test_a_saved_centreline_reports_as_connected_geometry(self):
+        _, nodes, _ = generate(seed=4, niter=6)
+        with tempfile.TemporaryDirectory() as out:
+            path = os.path.join(out, "net.npz")
+            save_network(path, nodes)
+            with contextlib.redirect_stdout(io.StringIO()) as captured:
+                extra = check_centreline(path)
+        self.assertEqual(extra, 0)
+        self.assertIn("(connected)", captured.getvalue())
 
 
 class CentrelinePersistenceTests(unittest.TestCase):

--- a/tests/test_vsystem.py
+++ b/tests/test_vsystem.py
@@ -31,7 +31,7 @@ from computeVoxel import (process_network, rasterise_segments, fit_to_volume,  #
                           normalise_axes, rasterise_line)
 from main import generate_network, load_network, save_network, write_volume  # noqa: E402
 from check_connectivity import (label, check_volume, check_centreline,  # noqa: E402
-                                generate_and_check)
+                                generate_and_check, report_centreline)
 
 PROPERTIES = {"k": 3, "epsilon": 7.0, "randmarg": 0.2, "sigma": 5, "stochparams": True}
 
@@ -748,6 +748,93 @@ class ConnectivityReportTests(unittest.TestCase):
                 extra = check_centreline(path)
         self.assertEqual(extra, 0)
         self.assertIn("(connected)", captured.getvalue())
+
+
+class BoundedGrowthTests(unittest.TestCase):
+    """
+    Growth confined to a box: a branch that would leave it is terminated along
+    with its subtree, so the tree takes the box's shape and no vessel is cut
+    part way along.
+    """
+
+    def setUp(self):
+        setProperties(PROPERTIES)
+
+    def test_a_box_larger_than_the_tree_changes_nothing(self):
+        seed_all(2)
+        program = F(6, 20.0)
+        free = np.array(list(branching_turtle_to_coords(program, 20.0)), dtype=float)
+        roomy = np.array(list(branching_turtle_to_coords(
+            program, 20.0, bounds=((-1e6,) * 3, (1e6,) * 3))), dtype=float)
+        np.testing.assert_array_equal(free, roomy)
+
+    def test_no_point_leaves_the_box_and_the_box_really_bites(self):
+        seed_all(2)
+        program = F(8, 20.0)
+        low = np.array([-200.0, 0.0, -200.0])
+        high = np.array([200.0, 400.0, 200.0])
+        rows = np.array(list(branching_turtle_to_coords(program, 20.0, bounds=(low, high))))
+        points = rows[~np.isnan(rows[:, 0])][:, :3]
+        self.assertGreater(len(points), 10)
+        self.assertTrue(np.all(points >= low - 1e-9))
+        self.assertTrue(np.all(points <= high + 1e-9))
+        free = np.array([r for r in branching_turtle_to_coords(program, 20.0)
+                         if not math.isnan(r[0])])[:, :3]
+        self.assertTrue(np.any(free > high) or np.any(free < low))   # it was not a no-op
+        self.assertLess(len(points), len(free))
+
+    def test_a_terminated_branch_leaves_the_centreline_connected(self):
+        seed_all(2)
+        rows = list(branching_turtle_to_coords(
+            F(8, 20.0), 20.0, bounds=((-150.0, 0.0, -150.0), (150.0, 300.0, 150.0))))
+        with contextlib.redirect_stdout(io.StringIO()):
+            self.assertEqual(report_centreline(interpolate_segments(rows), "bounded"), 0)
+
+    def test_bad_bounds_and_a_start_outside_them_are_refused(self):
+        for bounds in (((0, 0, 0), (0, 1, 1)), ((0, 0), (1, 1)), ((5, 5, 5), (1, 1, 1))):
+            with self.subTest(bounds=bounds):
+                with self.assertRaises(ValueError):
+                    list(branching_turtle_to_coords("f(1,1)", 1.0, bounds=bounds))
+        with self.assertRaises(ValueError):
+            list(branching_turtle_to_coords("f(1,1)", 1.0, position=(9.0, 0.0, 0.0),
+                                            bounds=((0, 0, 0), (1, 1, 1))))
+
+    def test_growing_in_a_slab_fills_it_without_cutting(self):
+        tVol = (96, 96, 32)
+        seed_all(5)
+        volume, _, nodes = generate_network(9, 20.0, PROPERTIES, tVol, grow_in_volume=True)
+        points, _ = fit_to_volume(nodes, tVol, fit="isotropic", clip_axes=())
+        finite = ~np.isnan(points[0])
+        self.assertTrue(np.all(points[:, finite] >= 0))
+        self.assertTrue(np.all(points[:, finite] < np.array(tVol)[:, None]))
+        total, reached = connected_count(volume, 6)
+        self.assertGreater(total, 0)
+        self.assertEqual(total, reached)          # one piece, unlike the clipped default
+
+    def test_growing_in_the_volume_needs_a_voxel_size_under_that_fit(self):
+        with self.assertRaises(ValueError):
+            generate_network(4, 20.0, PROPERTIES, (32, 32, 32), fit="voxel_size",
+                             voxel_size=None, grow_in_volume=True)
+
+    def test_grow_in_volume_reaches_the_sidecar_and_renders_one_piece(self):
+        import json
+        import tifffile
+        from main import main
+
+        args = ["--count", "1", "--seed", "5", "--volume", "64", "64", "24",
+                "--iterations", "7", "7", "--grow-in-volume"]
+        with tempfile.TemporaryDirectory() as out:
+            self.assertEqual(main(args + ["--out", out]), 0)
+            stem = next(n[:-5] for n in os.listdir(out) if n.endswith(".tiff"))
+            with open(os.path.join(out, stem + ".json")) as handle:
+                record = json.load(handle)
+            self.assertTrue(record["grow_in_volume"])
+            self.assertEqual(record["clip_axes"], [])
+            written = tifffile.imread(os.path.join(out, stem + ".tiff"))
+            volume = (np.transpose(written, (2, 1, 0)) > 0).astype(np.uint8)
+            total, reached = connected_count(volume, 6)
+            self.assertGreater(total, 0)
+            self.assertEqual(total, reached)
 
 
 class CentrelinePersistenceTests(unittest.TestCase):

--- a/tests/test_vsystem.py
+++ b/tests/test_vsystem.py
@@ -717,6 +717,28 @@ class ConnectivityReportTests(unittest.TestCase):
         self.assertEqual(failed, 1)
         self.assertIn("touch NO face", captured.getvalue())
 
+    def test_an_unreadable_path_is_not_counted_as_a_break(self):
+        from check_connectivity import main as connectivity_main
+        with contextlib.redirect_stdout(io.StringIO()) as out, \
+                contextlib.redirect_stderr(io.StringIO()) as err:
+            status = connectivity_main(["no_such_file.tiff", "#", "a comment"])
+        self.assertEqual(status, 1)
+        self.assertIn("no such file", err.getvalue())
+        self.assertIn("3 path(s) could not be read", out.getvalue())
+        self.assertNotIn("break(s)", out.getvalue())
+
+    def test_a_clean_run_says_so(self):
+        from check_connectivity import main as connectivity_main
+        body = np.zeros((12, 12, 12), dtype=np.uint8)
+        body[3:9, 3:9, 3:9] = 1
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "v.tiff")
+            write_volume(path, body)
+            with contextlib.redirect_stdout(io.StringIO()) as out:
+                status = connectivity_main([path])
+        self.assertEqual(status, 0)
+        self.assertIn("no break beyond what the volume cut", out.getvalue())
+
     def test_a_saved_centreline_reports_as_connected_geometry(self):
         _, nodes, _ = generate(seed=4, niter=6)
         with tempfile.TemporaryDirectory() as out:


### PR DESCRIPTION
Counting the components of a rendered network does not say whether it is defective. A tree larger than the volume it is rendered into is cut by the boundary, and the pieces that leaves are expected; a break away from any face is not. This adds a tool that tells the two apart, and an opt-in generation mode that removes the first cause entirely.

## `check_connectivity.py`

A volume is counted under six-connectivity — what a flood fill, a label or a morphological operation assumes unless told otherwise — and under 26-connectivity alongside it, since a chain of voxels touching only at corners is one piece to the second and many to the first. Every component but the largest is then tested against the six faces:

```
Lnet_i12_s5.tiff: 512x512x140, 77397 vessel voxels
    components: 48 six-connected, 45 26-connected; largest holds 94.8%
    of the 47 smaller pieces, 47 touch a face of the volume (cut by it: x 0, y 0, z 47)
    every break is the volume cutting the network, not a defect
```

A saved `.npz` centreline is checked as geometry instead: its branches are joined wherever they share a point, so the answer is independent of any volume and anything but one component is a defect in generation or interpretation.

`--generate N` makes fresh networks to check rather than reading files, passing every other option through to the generator, so the networks are the ones `main.py` would write for the same seeds and settings. Nothing is written to disk. The exit status is 1 only for a break the boundary does not explain, so a pipeline can gate on it while a clipped slab passes.

Labelling is union-find over the set voxels, so this adds no dependency.

## `--grow-in-volume`

The generator grows a tree in unbounded grammar-unit space and the volume is applied only at the end, as one scale factor and a crop. The tree is therefore whatever shape the grammar makes it — roughly cubical — and rendering it into a volume of different proportions cuts every branch that crosses a face. On the default `512 × 512 × 140` slab that is not incidental: the fit sizes the tree against x and y and ignores z, so a twelve-generation tree is 436 voxels deep in a 140-voxel volume, half of it falls outside, and the remainder renders as dozens of pieces.

This flag couples growth to the volume instead. The turtle interpreter takes an optional box in grammar units, and a move that would leave it terminates its branch: the move and the whole subtree descending from it are skipped, up to the bracket closing the branch. `main` sizes that box to the volume's proportions — the field of view under the `voxel_size` fit, otherwise the largest box of those proportions the tree still overflows — and starts the turtle inside it. Because whole branches are dropped rather than cut, the rendered network is one connected piece.

On `512 × 512 × 140` at twelve generations:

| | components | vessel voxels | root | P90 diameter |
| --- | --- | --- | --- | --- |
| default | 43 | 76852 | 11.4 vx | 1.90 |
| `--grow-in-volume` | **1** | **86888** | 12.7 vx | 2.17 |

The vessel count rises because branches that used to grow out of the slab and be discarded now stay within it. The tree spans 460 × 460 × 125 of the volume, so it fills the slab rather than being a cropped cube.

A volume with equal axes needs none of this, since the grammar's tree is already roughly cubical: `--volume 512 512 512 --clip-axes none` is one connected piece at the same calibre. The README documents both routes.

## Behaviour

The flag is off by default and `--clip-axes` is unused when it is set. Output for every existing invocation is unchanged, verified by regenerating two networks without the flag and diffing against the pre-change binaries — byte-identical. Under the `voxel_size` fit the flag errors without a voxel size rather than guessing a field of view.

## Verification

85 tests, pyflakes clean. The new tests cover component counting and ordering, the corner-touching chain that splits under six-connectivity but not 26, a piece on a face versus one inside, an unreadable path not being counted as a break, generation through `--generate`, that a box larger than the tree changes nothing, that no point leaves the box while a free run does, that a terminated branch leaves the centreline connected, malformed bounds and a start outside them, and that `--grow-in-volume` reaches the sidecar and renders one piece.